### PR TITLE
feat: add Ruler of the Skies (B4)

### DIFF
--- a/cards/en/b4-ruler-of-the-skies.json
+++ b/cards/en/b4-ruler-of-the-skies.json
@@ -1,0 +1,5946 @@
+[
+  {
+    "id": "b4-001",
+    "name": "Wurmple",
+    "element": "Grass",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 60,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Gnaw",
+        "damage": "10",
+        "cost": [
+          "Colorless"
+        ]
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Fire",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Common"
+  },
+  {
+    "id": "b4-002",
+    "name": "Silcoon",
+    "element": "Grass",
+    "type": "Pokemon",
+    "subtype": "Stage 1",
+    "health": 80,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Cocoon Collector",
+        "damage": "",
+        "cost": [
+          "Colorless"
+        ],
+        "effect": "Put 3 random cards from among Silcoon and Cascoon from your deck onto your Bench."
+      }
+    ],
+    "retreatCost": "3",
+    "weakness": "Fire",
+    "abilities": [],
+    "evolvesFrom": "Wurmple",
+    "rarity": "Common"
+  },
+  {
+    "id": "b4-003",
+    "name": "Beautifly",
+    "element": "Grass",
+    "type": "Pokemon",
+    "subtype": "Stage 2",
+    "health": 130,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Evoflight",
+        "damage": "30+",
+        "cost": [
+          "Grass"
+        ],
+        "effect": "This attack does 30 more damage for each Evolution Pokémon on your Bench."
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Fire",
+    "abilities": [],
+    "evolvesFrom": "Silcoon",
+    "rarity": "Uncommon"
+  },
+  {
+    "id": "b4-004",
+    "name": "Cascoon",
+    "element": "Grass",
+    "type": "Pokemon",
+    "subtype": "Stage 1",
+    "health": 80,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Cocoon Collector",
+        "damage": "",
+        "cost": [
+          "Colorless"
+        ],
+        "effect": "Put 3 random cards from among Silcoon and Cascoon from your deck onto your Bench."
+      }
+    ],
+    "retreatCost": "3",
+    "weakness": "Fire",
+    "abilities": [],
+    "evolvesFrom": "Wurmple",
+    "rarity": "Common"
+  },
+  {
+    "id": "b4-005",
+    "name": "Dustox",
+    "element": "Grass",
+    "type": "Pokemon",
+    "subtype": "Stage 2",
+    "health": 120,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Cutting Wind",
+        "damage": "60",
+        "cost": [
+          "Colorless",
+          "Colorless"
+        ]
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Fire",
+    "abilities": [
+      {
+        "name": "Variety Powder",
+        "effect": "Once during your turn, you may use this Ability. 1 Special Condition from among Burned, Confused, and Poisoned is chosen at random, and your opponent's Active Pokémon is now affected by that Special Condition. Any Special Conditions already affecting that Pokémon will not be chosen."
+      }
+    ],
+    "evolvesFrom": "Cascoon",
+    "rarity": "Rare"
+  },
+  {
+    "id": "b4-006",
+    "name": "Lileep",
+    "element": "Grass",
+    "type": "Pokemon",
+    "subtype": "Stage 1",
+    "health": 90,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Blot",
+        "damage": "40",
+        "cost": [
+          "Grass"
+        ],
+        "effect": "Heal 10 damage from this Pokémon."
+      }
+    ],
+    "retreatCost": "2",
+    "weakness": "Fire",
+    "abilities": [],
+    "evolvesFrom": "Root Fossil",
+    "rarity": "Uncommon"
+  },
+  {
+    "id": "b4-007",
+    "name": "Cradily",
+    "element": "Grass",
+    "type": "Pokemon",
+    "subtype": "Stage 2",
+    "health": 150,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Stick and Absorb",
+        "damage": "70",
+        "cost": [
+          "Grass",
+          "Grass"
+        ],
+        "effect": "Heal 30 damage from this Pokémon. During your opponent's next turn, the Defending Pokémon can't retreat."
+      }
+    ],
+    "retreatCost": "3",
+    "weakness": "Fire",
+    "abilities": [],
+    "evolvesFrom": "Lileep",
+    "rarity": "Rare"
+  },
+  {
+    "id": "b4-008",
+    "name": "Kricketot",
+    "element": "Grass",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 60,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Beat",
+        "damage": "10",
+        "cost": [
+          "Colorless"
+        ]
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Fire",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Common"
+  },
+  {
+    "id": "b4-009",
+    "name": "Kricketune",
+    "element": "Grass",
+    "type": "Pokemon",
+    "subtype": "Stage 1",
+    "health": 90,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Bug Buzz",
+        "damage": "50",
+        "cost": [
+          "Grass"
+        ]
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Fire",
+    "abilities": [],
+    "evolvesFrom": "Kricketot",
+    "rarity": "Common"
+  },
+  {
+    "id": "b4-010",
+    "name": "Combee",
+    "element": "Grass",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 50,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Reckless Charge",
+        "damage": "30",
+        "cost": [
+          "Grass"
+        ],
+        "effect": "This Pokémon also does 10 damage to itself."
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Fire",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Common"
+  },
+  {
+    "id": "b4-011",
+    "name": "Vespiquen ex",
+    "element": "Grass",
+    "type": "Pokemon",
+    "subtype": "Stage 1",
+    "health": 140,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Chase Order",
+        "damage": "70+",
+        "cost": [
+          "Grass",
+          "Grass"
+        ],
+        "effect": "You may discard 1 of your Benched Basic Grass Pokémon. If you do, this attack does 70 more damage."
+      }
+    ],
+    "retreatCost": "2",
+    "weakness": "Fire",
+    "abilities": [],
+    "evolvesFrom": "Combee",
+    "rarity": "Rare EX"
+  },
+  {
+    "id": "b4-012",
+    "name": "Karrablast",
+    "element": "Grass",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 60,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Peck",
+        "damage": "30",
+        "cost": [
+          "Colorless",
+          "Colorless"
+        ]
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Fire",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Common"
+  },
+  {
+    "id": "b4-013",
+    "name": "Shelmet",
+    "element": "Grass",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 70,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Seashell Attack",
+        "damage": "20",
+        "cost": [
+          "Colorless"
+        ]
+      }
+    ],
+    "retreatCost": "3",
+    "weakness": "Fire",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Common"
+  },
+  {
+    "id": "b4-014",
+    "name": "Accelgor",
+    "element": "Grass",
+    "type": "Pokemon",
+    "subtype": "Stage 1",
+    "health": 80,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Deck and Cover",
+        "damage": "50",
+        "cost": [
+          "Colorless",
+          "Colorless"
+        ],
+        "effect": "Your opponent's Active Pokémon is now Poisoned and Paralyzed. Shuffle this Pokémon and all attached cards into your deck."
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Fire",
+    "abilities": [],
+    "evolvesFrom": "Shelmet",
+    "rarity": "Rare"
+  },
+  {
+    "id": "b4-015",
+    "name": "Dhelmise",
+    "element": "Grass",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 110,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Spinning Attack",
+        "damage": "70",
+        "cost": [
+          "Grass",
+          "Grass",
+          "Colorless"
+        ]
+      }
+    ],
+    "retreatCost": "2",
+    "weakness": "Fire",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Common"
+  },
+  {
+    "id": "b4-016",
+    "name": "Pheromosa",
+    "element": "Grass",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 70,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Prelude",
+        "damage": "30+",
+        "cost": [
+          "Grass",
+          "Grass"
+        ],
+        "effect": "If you haven't gotten any points, this attack does 60 more damage."
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Fire",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Uncommon"
+  },
+  {
+    "id": "b4-017",
+    "name": "Poltchageist",
+    "element": "Grass",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 40,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Spray Fluid",
+        "damage": "10",
+        "cost": [
+          "Grass"
+        ]
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Fire",
+    "abilities": [
+      {
+        "name": "Hospitality",
+        "effect": "Once during your turn, when you put this Pokémon from your hand onto your Bench, you may heal 20 damage from your Active Grass Pokémon."
+      }
+    ],
+    "evolvesFrom": null,
+    "rarity": "Common"
+  },
+  {
+    "id": "b4-018",
+    "name": "Sinistcha",
+    "element": "Grass",
+    "type": "Pokemon",
+    "subtype": "Stage 1",
+    "health": 80,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Scald",
+        "damage": "40",
+        "cost": [
+          "Grass",
+          "Colorless"
+        ],
+        "effect": "Your opponent's Active Pokémon is now Burned."
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Fire",
+    "abilities": [],
+    "evolvesFrom": "Poltchageist",
+    "rarity": "Uncommon"
+  },
+  {
+    "id": "b4-019",
+    "name": "Teal Mask Ogerpon",
+    "element": "Grass",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 90,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Ogre’s Whip",
+        "damage": "",
+        "cost": [
+          "Grass",
+          "Grass",
+          "Colorless"
+        ],
+        "effect": "This attack does damage to your opponent's Active Pokémon equal to this Pokémon's remaining HP."
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Fire",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Rare"
+  },
+  {
+    "id": "b4-020",
+    "name": "Ponyta",
+    "element": "Fire",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 60,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Stoke",
+        "damage": "",
+        "cost": [
+          "Fire"
+        ],
+        "effect": "Take a Fire Energy from your Energy Zone and attach it to this Pokémon."
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Water",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Common"
+  },
+  {
+    "id": "b4-021",
+    "name": "Rapidash",
+    "element": "Fire",
+    "type": "Pokemon",
+    "subtype": "Stage 1",
+    "health": 110,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Heat Blast",
+        "damage": "80",
+        "cost": [
+          "Fire",
+          "Fire",
+          "Colorless"
+        ]
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Water",
+    "abilities": [],
+    "evolvesFrom": "Ponyta",
+    "rarity": "Uncommon"
+  },
+  {
+    "id": "b4-022",
+    "name": "Flareon",
+    "element": "Fire",
+    "type": "Pokemon",
+    "subtype": "Stage 1",
+    "health": 110,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Bursting Tail",
+        "damage": "70",
+        "cost": [
+          "Fire",
+          "Fire"
+        ],
+        "effect": "Discard FireFire Energy from this Pokémon. Your opponent's Active Pokémon is now Burned."
+      }
+    ],
+    "retreatCost": "2",
+    "weakness": "Water",
+    "abilities": [],
+    "evolvesFrom": "Eevee",
+    "rarity": "Uncommon"
+  },
+  {
+    "id": "b4-023",
+    "name": "Moltres",
+    "element": "Fire",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 100,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Sky Attack",
+        "damage": "150",
+        "cost": [
+          "Fire",
+          "Colorless",
+          "Colorless",
+          "Colorless"
+        ],
+        "effect": "Flip a coin. If tails, this attack does nothing."
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Lightning",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Rare"
+  },
+  {
+    "id": "b4-024",
+    "name": "Cyndaquil",
+    "element": "Fire",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 60,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Singe",
+        "damage": "",
+        "cost": [
+          "Fire"
+        ],
+        "effect": "Your opponent's Active Pokémon is now Burned."
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Water",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Common"
+  },
+  {
+    "id": "b4-025",
+    "name": "Quilava",
+    "element": "Fire",
+    "type": "Pokemon",
+    "subtype": "Stage 1",
+    "health": 80,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Heat Wave",
+        "damage": "30",
+        "cost": [
+          "Fire",
+          "Fire"
+        ],
+        "effect": "Your opponent's Active Pokémon is now Burned."
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Water",
+    "abilities": [],
+    "evolvesFrom": "Cyndaquil",
+    "rarity": "Uncommon"
+  },
+  {
+    "id": "b4-026",
+    "name": "Typhlosion ex",
+    "element": "Fire",
+    "type": "Pokemon",
+    "subtype": "Stage 2",
+    "health": 180,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Destructive Inferno",
+        "damage": "110",
+        "cost": [
+          "Fire",
+          "Fire",
+          "Colorless"
+        ],
+        "effect": "Flip a coin until you get tails. For each heads, discard a random Energy from your opponent's Active Pokémon."
+      }
+    ],
+    "retreatCost": "2",
+    "weakness": "Water",
+    "abilities": [],
+    "evolvesFrom": "Quilava",
+    "rarity": "Rare EX"
+  },
+  {
+    "id": "b4-027",
+    "name": "Houndour",
+    "element": "Fire",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 60,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Sharp Claws",
+        "damage": "10+",
+        "cost": [
+          "Fire"
+        ],
+        "effect": "Flip a coin. If heads, this attack does 20 more damage."
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Water",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Common"
+  },
+  {
+    "id": "b4-028",
+    "name": "Houndoom",
+    "element": "Fire",
+    "type": "Pokemon",
+    "subtype": "Stage 1",
+    "health": 100,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Crunch",
+        "damage": "60",
+        "cost": [
+          "Fire",
+          "Fire"
+        ],
+        "effect": "Flip a coin. If heads, discard a random Energy from your opponent's Active Pokémon."
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Water",
+    "abilities": [],
+    "evolvesFrom": "Houndour",
+    "rarity": "Uncommon"
+  },
+  {
+    "id": "b4-029",
+    "name": "Heatmor",
+    "element": "Fire",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 90,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Fire Claws",
+        "damage": "50",
+        "cost": [
+          "Fire",
+          "Colorless"
+        ]
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Water",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Common"
+  },
+  {
+    "id": "b4-030",
+    "name": "Psyduck",
+    "element": "Water",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 60,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Migraine",
+        "damage": "10",
+        "cost": [
+          "Colorless"
+        ],
+        "effect": "Flip a coin. If heads, your opponent's Active Pokémon is now Confused. If tails, this Pokémon is now Confused."
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Lightning",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Common"
+  },
+  {
+    "id": "b4-031",
+    "name": "Golduck",
+    "element": "Water",
+    "type": "Pokemon",
+    "subtype": "Stage 1",
+    "health": 110,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Surf",
+        "damage": "80",
+        "cost": [
+          "Water",
+          "Water",
+          "Colorless"
+        ]
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Lightning",
+    "abilities": [],
+    "evolvesFrom": "Psyduck",
+    "rarity": "Common"
+  },
+  {
+    "id": "b4-032",
+    "name": "Staryu",
+    "element": "Water",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 50,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Swift",
+        "damage": "20",
+        "cost": [
+          "Water"
+        ],
+        "effect": "This attack's damage isn't affected by Weakness or by any effects on your opponent's Active Pokémon."
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Lightning",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Common"
+  },
+  {
+    "id": "b4-033",
+    "name": "Starmie",
+    "element": "Water",
+    "type": "Pokemon",
+    "subtype": "Stage 1",
+    "health": 90,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Swift",
+        "damage": "60",
+        "cost": [
+          "Water",
+          "Colorless"
+        ],
+        "effect": "This attack's damage isn't affected by Weakness or by any effects on your opponent's Active Pokémon."
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Lightning",
+    "abilities": [],
+    "evolvesFrom": "Staryu",
+    "rarity": "Uncommon"
+  },
+  {
+    "id": "b4-034",
+    "name": "Carvanha",
+    "element": "Water",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 50,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Sharp Fang",
+        "damage": "30",
+        "cost": [
+          "Water"
+        ]
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Lightning",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Common"
+  },
+  {
+    "id": "b4-035",
+    "name": "Mega Sharpedo ex",
+    "element": "Water",
+    "type": "Pokemon",
+    "subtype": "Stage 1",
+    "health": 190,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Turbo Shark",
+        "damage": "70",
+        "cost": [
+          "Water"
+        ],
+        "effect": "Take a Water Energy from your Energy Zone and attach it to 1 of your Benched Water Pokémon."
+      }
+    ],
+    "retreatCost": "0",
+    "weakness": "Lightning",
+    "abilities": [],
+    "evolvesFrom": "Carvanha",
+    "rarity": "Rare EX"
+  },
+  {
+    "id": "b4-036",
+    "name": "Wailmer",
+    "element": "Water",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 100,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Wave Splash",
+        "damage": "60",
+        "cost": [
+          "Water",
+          "Water",
+          "Water"
+        ]
+      }
+    ],
+    "retreatCost": "3",
+    "weakness": "Lightning",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Common"
+  },
+  {
+    "id": "b4-037",
+    "name": "Wailord ex",
+    "element": "Water",
+    "type": "Pokemon",
+    "subtype": "Stage 1",
+    "health": 250,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Wondrous Waves",
+        "damage": "100",
+        "cost": [
+          "Water",
+          "Water",
+          "Water",
+          "Water"
+        ],
+        "effect": "This Pokémon recovers from all Special Conditions."
+      }
+    ],
+    "retreatCost": "4",
+    "weakness": "Lightning",
+    "abilities": [],
+    "evolvesFrom": "Wailmer",
+    "rarity": "Rare EX"
+  },
+  {
+    "id": "b4-038",
+    "name": "Spheal",
+    "element": "Water",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 60,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Rollout",
+        "damage": "30",
+        "cost": [
+          "Water",
+          "Colorless"
+        ]
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Metal",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Common"
+  },
+  {
+    "id": "b4-039",
+    "name": "Sealeo",
+    "element": "Water",
+    "type": "Pokemon",
+    "subtype": "Stage 1",
+    "health": 100,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Frozen Splash",
+        "damage": "50+",
+        "cost": [
+          "Water",
+          "Water",
+          "Colorless"
+        ],
+        "effect": "If your opponent's Active Pokémon is a Fighting Pokémon, this attack does 70 more damage."
+      }
+    ],
+    "retreatCost": "3",
+    "weakness": "Metal",
+    "abilities": [],
+    "evolvesFrom": "Spheal",
+    "rarity": "Uncommon"
+  },
+  {
+    "id": "b4-040",
+    "name": "Walrein",
+    "element": "Water",
+    "type": "Pokemon",
+    "subtype": "Stage 2",
+    "health": 160,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Blizzlock",
+        "damage": "110",
+        "cost": [
+          "Water",
+          "Water",
+          "Colorless",
+          "Colorless"
+        ],
+        "effect": "Your opponent can't use any Supporter cards from their hand during their next turn."
+      }
+    ],
+    "retreatCost": "4",
+    "weakness": "Metal",
+    "abilities": [],
+    "evolvesFrom": "Sealeo",
+    "rarity": "Rare"
+  },
+  {
+    "id": "b4-041",
+    "name": "Kyogre",
+    "element": "Water",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 120,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Tidal Blast",
+        "damage": "",
+        "cost": [
+          "Water",
+          "Water",
+          "Water",
+          "Water"
+        ],
+        "effect": "Discard 3 Water Energy from this Pokémon, and this attack does 50 damage to each of your opponent's Pokémon."
+      }
+    ],
+    "retreatCost": "2",
+    "weakness": "Lightning",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Rare"
+  },
+  {
+    "id": "b4-042",
+    "name": "Oshawott",
+    "element": "Water",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 60,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Water Gun",
+        "damage": "20",
+        "cost": [
+          "Water"
+        ]
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Lightning",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Common"
+  },
+  {
+    "id": "b4-043",
+    "name": "Dewott",
+    "element": "Water",
+    "type": "Pokemon",
+    "subtype": "Stage 1",
+    "health": 80,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Razor Shell",
+        "damage": "20+",
+        "cost": [
+          "Water"
+        ],
+        "effect": "Flip a coin. If heads, this attack does 30 more damage."
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Lightning",
+    "abilities": [],
+    "evolvesFrom": "Oshawott",
+    "rarity": "Uncommon"
+  },
+  {
+    "id": "b4-044",
+    "name": "Samurott",
+    "element": "Water",
+    "type": "Pokemon",
+    "subtype": "Stage 2",
+    "health": 150,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Pike",
+        "damage": "60",
+        "cost": [
+          "Water",
+          "Water"
+        ],
+        "effect": "This attack also does 20 damage to 1 of your opponent's Benched Pokémon."
+      }
+    ],
+    "retreatCost": "2",
+    "weakness": "Lightning",
+    "abilities": [
+      {
+        "name": "Stance",
+        "effect": "Once during your turn, when you play this Pokémon from your hand to evolve 1 of your Pokémon, you may prevent all damage from—and effects of—attacks from your opponent's Pokémon done to this Pokémon until the end of your opponent's next turn."
+      }
+    ],
+    "evolvesFrom": "Dewott",
+    "rarity": "Rare"
+  },
+  {
+    "id": "b4-045",
+    "name": "Alomomola",
+    "element": "Water",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 100,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Mineral Pump",
+        "damage": "40",
+        "cost": [
+          "Water",
+          "Water"
+        ],
+        "effect": "Heal 10 damage from each of your Benched Pokémon."
+      }
+    ],
+    "retreatCost": "2",
+    "weakness": "Lightning",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Uncommon"
+  },
+  {
+    "id": "b4-046",
+    "name": "Dewpider",
+    "element": "Water",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 60,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Wave Splash",
+        "damage": "20",
+        "cost": [
+          "Water"
+        ]
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Lightning",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Common"
+  },
+  {
+    "id": "b4-047",
+    "name": "Araquanid",
+    "element": "Water",
+    "type": "Pokemon",
+    "subtype": "Stage 1",
+    "health": 100,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Corner",
+        "damage": "60",
+        "cost": [
+          "Water",
+          "Colorless"
+        ],
+        "effect": "During your opponent's next turn, the Defending Pokémon can't retreat."
+      }
+    ],
+    "retreatCost": "2",
+    "weakness": "Lightning",
+    "abilities": [],
+    "evolvesFrom": "Dewpider",
+    "rarity": "Uncommon"
+  },
+  {
+    "id": "b4-048",
+    "name": "Bruxish",
+    "element": "Water",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 80,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Bite",
+        "damage": "30",
+        "cost": [
+          "Water"
+        ]
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Lightning",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Common"
+  },
+  {
+    "id": "b4-049",
+    "name": "Pikachu",
+    "element": "Lightning",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 60,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Growl",
+        "damage": "",
+        "cost": [
+          "Colorless"
+        ],
+        "effect": "During your opponent's next turn, attacks used by the Defending Pokémon do −20 damage."
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Fighting",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Common"
+  },
+  {
+    "id": "b4-050",
+    "name": "Raichu",
+    "element": "Lightning",
+    "type": "Pokemon",
+    "subtype": "Stage 1",
+    "health": 100,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Electro Ball",
+        "damage": "50",
+        "cost": [
+          "Lightning",
+          "Colorless"
+        ]
+      }
+    ],
+    "retreatCost": "2",
+    "weakness": "Fighting",
+    "abilities": [
+      {
+        "name": "Evoshock",
+        "effect": "Once during your turn, when you play this Pokémon from your hand to evolve 1 of your Pokémon, you may flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+      }
+    ],
+    "evolvesFrom": "Pikachu",
+    "rarity": "Rare"
+  },
+  {
+    "id": "b4-051",
+    "name": "Shinx",
+    "element": "Lightning",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 60,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Static Shock",
+        "damage": "30",
+        "cost": [
+          "Lightning",
+          "Colorless"
+        ]
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Fighting",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Common"
+  },
+  {
+    "id": "b4-052",
+    "name": "Luxio",
+    "element": "Lightning",
+    "type": "Pokemon",
+    "subtype": "Stage 1",
+    "health": 70,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Zap Kick",
+        "damage": "40",
+        "cost": [
+          "Lightning",
+          "Colorless"
+        ]
+      }
+    ],
+    "retreatCost": "0",
+    "weakness": "Fighting",
+    "abilities": [],
+    "evolvesFrom": "Shinx",
+    "rarity": "Uncommon"
+  },
+  {
+    "id": "b4-053",
+    "name": "Luxray",
+    "element": "Lightning",
+    "type": "Pokemon",
+    "subtype": "Stage 2",
+    "health": 140,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Revenge Blast",
+        "damage": "80+",
+        "cost": [
+          "Lightning",
+          "Lightning",
+          "Colorless"
+        ],
+        "effect": "This attack does 50 more damage for each point your opponent has gotten."
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Fighting",
+    "abilities": [],
+    "evolvesFrom": "Luxio",
+    "rarity": "Rare"
+  },
+  {
+    "id": "b4-054",
+    "name": "Pachirisu",
+    "element": "Lightning",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 70,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Crackling Snap",
+        "damage": "30+",
+        "cost": [
+          "Lightning"
+        ],
+        "effect": "Discard the top card of your deck, and if that card is an Item, this attack does 20 more damage."
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Fighting",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Common"
+  },
+  {
+    "id": "b4-055",
+    "name": "Rotom ex",
+    "element": "Lightning",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 120,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Junk Spark",
+        "damage": "30+",
+        "cost": [
+          "Lightning",
+          "Lightning"
+        ],
+        "effect": "This attack does 10 more damage for each Item card in your discard pile."
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Fighting",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Rare EX"
+  },
+  {
+    "id": "b4-056",
+    "name": "Tynamo",
+    "element": "Lightning",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 40,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Tackle",
+        "damage": "20",
+        "cost": [
+          "Lightning"
+        ]
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Fighting",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Common"
+  },
+  {
+    "id": "b4-057",
+    "name": "Eelektrik",
+    "element": "Lightning",
+    "type": "Pokemon",
+    "subtype": "Stage 1",
+    "health": 80,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Headbutt",
+        "damage": "50",
+        "cost": [
+          "Lightning",
+          "Colorless"
+        ]
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Fighting",
+    "abilities": [],
+    "evolvesFrom": "Tynamo",
+    "rarity": "Common"
+  },
+  {
+    "id": "b4-058",
+    "name": "Eelektross",
+    "element": "Lightning",
+    "type": "Pokemon",
+    "subtype": "Stage 2",
+    "health": 140,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Energy Crush",
+        "damage": "50+",
+        "cost": [
+          "Lightning",
+          "Colorless"
+        ],
+        "effect": "This attack does 20 more damage for each Energy attached to all of your opponent's Pokémon."
+      }
+    ],
+    "retreatCost": "3",
+    "weakness": "Fighting",
+    "abilities": [],
+    "evolvesFrom": "Eelektrik",
+    "rarity": "Uncommon"
+  },
+  {
+    "id": "b4-059",
+    "name": "Thundurus",
+    "element": "Lightning",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 100,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Disaster Volt",
+        "damage": "100",
+        "cost": [
+          "Lightning",
+          "Colorless",
+          "Colorless"
+        ],
+        "effect": "Discard a Lightning Energy from this Pokémon."
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Fighting",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Rare"
+  },
+  {
+    "id": "b4-060",
+    "name": "Helioptile",
+    "element": "Lightning",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 60,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Jumping Kick",
+        "damage": "",
+        "cost": [
+          "Lightning"
+        ],
+        "effect": "This attack does 10 damage to 1 of your opponent's Pokémon."
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Fighting",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Common"
+  },
+  {
+    "id": "b4-061",
+    "name": "Heliolisk",
+    "element": "Lightning",
+    "type": "Pokemon",
+    "subtype": "Stage 1",
+    "health": 80,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Electrispark",
+        "damage": "40",
+        "cost": [
+          "Lightning"
+        ],
+        "effect": "This attack also does 10 damage to each of your opponent's Benched Pokémon."
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Fighting",
+    "abilities": [],
+    "evolvesFrom": "Helioptile",
+    "rarity": "Uncommon"
+  },
+  {
+    "id": "b4-062",
+    "name": "Wattrel",
+    "element": "Lightning",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 60,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Peck",
+        "damage": "10",
+        "cost": [
+          "Colorless"
+        ]
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Lightning",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Common"
+  },
+  {
+    "id": "b4-063",
+    "name": "Kilowattrel",
+    "element": "Lightning",
+    "type": "Pokemon",
+    "subtype": "Stage 1",
+    "health": 90,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Electro Ball",
+        "damage": "70",
+        "cost": [
+          "Lightning",
+          "Lightning"
+        ]
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Lightning",
+    "abilities": [],
+    "evolvesFrom": "Wattrel",
+    "rarity": "Uncommon"
+  },
+  {
+    "id": "b4-064",
+    "name": "Clefairy",
+    "element": "Psychic",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 60,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Mini-Metronome",
+        "damage": "",
+        "cost": [
+          "Colorless",
+          "Colorless",
+          "Colorless"
+        ],
+        "effect": "Flip a coin. If heads, choose 1 of your opponent's Active Pokémon's attacks and use it as this attack."
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Metal",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Common"
+  },
+  {
+    "id": "b4-065",
+    "name": "Clefable",
+    "element": "Psychic",
+    "type": "Pokemon",
+    "subtype": "Stage 1",
+    "health": 110,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Hyper Voice",
+        "damage": "70",
+        "cost": [
+          "Colorless",
+          "Colorless",
+          "Colorless"
+        ]
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Metal",
+    "abilities": [],
+    "evolvesFrom": "Clefairy",
+    "rarity": "Common"
+  },
+  {
+    "id": "b4-066",
+    "name": "Drowzee",
+    "element": "Psychic",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 70,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Ram",
+        "damage": "20",
+        "cost": [
+          "Colorless",
+          "Colorless"
+        ]
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Darkness",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Common"
+  },
+  {
+    "id": "b4-067",
+    "name": "Hypno",
+    "element": "Psychic",
+    "type": "Pokemon",
+    "subtype": "Stage 1",
+    "health": 110,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Psychic",
+        "damage": "60+",
+        "cost": [
+          "Psychic",
+          "Psychic",
+          "Colorless"
+        ],
+        "effect": "This attack does 20 more damage for each Energy attached to your opponent's Active Pokémon."
+      }
+    ],
+    "retreatCost": "2",
+    "weakness": "Darkness",
+    "abilities": [],
+    "evolvesFrom": "Drowzee",
+    "rarity": "Uncommon"
+  },
+  {
+    "id": "b4-068",
+    "name": "Mime Jr.",
+    "element": "Psychic",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 30,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Mime-y Shuffle",
+        "damage": "",
+        "cost": [],
+        "effect": "Shuffle your hand into your deck. Draw a card for each card in your opponent's hand."
+      }
+    ],
+    "retreatCost": "0",
+    "weakness": null,
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Rare"
+  },
+  {
+    "id": "b4-069",
+    "name": "Mr. Mime",
+    "element": "Psychic",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 70,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Synchro Dance",
+        "damage": "40+",
+        "cost": [
+          "Psychic",
+          "Colorless"
+        ],
+        "effect": "If this Pokémon and your opponent's Active Pokémon have the same amount of Energy attached, this attack does 40 more damage."
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Darkness",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Common"
+  },
+  {
+    "id": "b4-070",
+    "name": "Mewtwo",
+    "element": "Psychic",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 120,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Psychic",
+        "damage": "10+",
+        "cost": [
+          "Psychic",
+          "Psychic",
+          "Psychic"
+        ],
+        "effect": "This attack does 40 more damage for each Energy attached to your opponent's Active Pokémon."
+      }
+    ],
+    "retreatCost": "2",
+    "weakness": "Darkness",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Rare"
+  },
+  {
+    "id": "b4-071",
+    "name": "Ralts",
+    "element": "Psychic",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 60,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Lead",
+        "damage": "",
+        "cost": [
+          "Colorless"
+        ],
+        "effect": "Put a random Supporter card from your deck into your hand."
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Darkness",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Common"
+  },
+  {
+    "id": "b4-072",
+    "name": "Kirlia",
+    "element": "Psychic",
+    "type": "Pokemon",
+    "subtype": "Stage 1",
+    "health": 80,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Double Spin",
+        "damage": "20x",
+        "cost": [
+          "Colorless"
+        ],
+        "effect": "Flip 2 coins. This attack does 20 damage for each heads."
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Darkness",
+    "abilities": [],
+    "evolvesFrom": "Ralts",
+    "rarity": "Uncommon"
+  },
+  {
+    "id": "b4-073",
+    "name": "Chimecho",
+    "element": "Psychic",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 70,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Extrasensory",
+        "damage": "40+",
+        "cost": [
+          "Psychic",
+          "Colorless"
+        ],
+        "effect": "If you have the same number of cards in your hand as your opponent, this attack does 40 more damage."
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Darkness",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Common"
+  },
+  {
+    "id": "b4-074",
+    "name": "Wynaut",
+    "element": "Psychic",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 30,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Stompy Jammer",
+        "damage": "10",
+        "cost": [],
+        "effect": "During your opponent's next turn, attacks used by the Defending Pokémon cost 1 Colorless more."
+      }
+    ],
+    "retreatCost": "0",
+    "weakness": null,
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Rare"
+  },
+  {
+    "id": "b4-075",
+    "name": "Woobat",
+    "element": "Psychic",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 60,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Air Cutter",
+        "damage": "40",
+        "cost": [
+          "Colorless"
+        ],
+        "effect": "Flip a coin. If tails, this attack does nothing."
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Darkness",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Common"
+  },
+  {
+    "id": "b4-076",
+    "name": "Swoobat",
+    "element": "Psychic",
+    "type": "Pokemon",
+    "subtype": "Stage 1",
+    "health": 90,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Mind Bend",
+        "damage": "40",
+        "cost": [
+          "Psychic"
+        ],
+        "effect": "Your opponent's Active Pokémon is now Confused."
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Darkness",
+    "abilities": [],
+    "evolvesFrom": "Woobat",
+    "rarity": "Common"
+  },
+  {
+    "id": "b4-077",
+    "name": "Hoopa",
+    "element": "Psychic",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 70,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Mischievous Ring",
+        "damage": "20",
+        "cost": [
+          "Colorless"
+        ],
+        "effect": "Before doing damage, shuffle all Pokémon Tools from each of your opponent's Pokémon into their deck."
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Darkness",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Uncommon"
+  },
+  {
+    "id": "b4-078",
+    "name": "Oricorio",
+    "element": "Psychic",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 80,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Supernatural Feather",
+        "damage": "50",
+        "cost": [
+          "Psychic"
+        ],
+        "effect": "Discard a card from your hand. If you can't, this attack does nothing."
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Darkness",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Uncommon"
+  },
+  {
+    "id": "b4-079",
+    "name": "Makuhita",
+    "element": "Fighting",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 70,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Magnum Punch",
+        "damage": "30",
+        "cost": [
+          "Fighting",
+          "Colorless"
+        ]
+      }
+    ],
+    "retreatCost": "2",
+    "weakness": "Psychic",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Common"
+  },
+  {
+    "id": "b4-080",
+    "name": "Hariyama",
+    "element": "Fighting",
+    "type": "Pokemon",
+    "subtype": "Stage 1",
+    "health": 120,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Pivot Throw",
+        "damage": "120",
+        "cost": [
+          "Fighting",
+          "Fighting",
+          "Colorless"
+        ],
+        "effect": "During your opponent's next turn, this Pokémon takes +50 damage from attacks."
+      }
+    ],
+    "retreatCost": "3",
+    "weakness": "Psychic",
+    "abilities": [],
+    "evolvesFrom": "Makuhita",
+    "rarity": "Uncommon"
+  },
+  {
+    "id": "b4-081",
+    "name": "Anorith",
+    "element": "Fighting",
+    "type": "Pokemon",
+    "subtype": "Stage 1",
+    "health": 90,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Slash",
+        "damage": "40",
+        "cost": [
+          "Fighting"
+        ]
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Grass",
+    "abilities": [],
+    "evolvesFrom": "Claw Fossil",
+    "rarity": "Uncommon"
+  },
+  {
+    "id": "b4-082",
+    "name": "Armaldo",
+    "element": "Fighting",
+    "type": "Pokemon",
+    "subtype": "Stage 2",
+    "health": 150,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Abyssal Drop",
+        "damage": "",
+        "cost": [
+          "Fighting",
+          "Colorless",
+          "Colorless"
+        ],
+        "effect": "Discard all Energy from this Pokémon. Choose a spot from among your opponent's Active Spot and Bench. At the end of your opponent's next turn, Knock Out the Pokémon in the spot you chose."
+      }
+    ],
+    "retreatCost": "3",
+    "weakness": "Grass",
+    "abilities": [],
+    "evolvesFrom": "Anorith",
+    "rarity": "Rare"
+  },
+  {
+    "id": "b4-083",
+    "name": "Groudon",
+    "element": "Fighting",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 130,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Earthquake",
+        "damage": "100",
+        "cost": [
+          "Fighting",
+          "Fighting",
+          "Fighting"
+        ],
+        "effect": "This attack also does 10 damage to each of your Benched Pokémon."
+      }
+    ],
+    "retreatCost": "4",
+    "weakness": "Grass",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Rare"
+  },
+  {
+    "id": "b4-084",
+    "name": "Mega Gallade ex",
+    "element": "Fighting",
+    "type": "Pokemon",
+    "subtype": "Stage 2",
+    "health": 220,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Resonating Blade",
+        "damage": "100+",
+        "cost": [
+          "Fighting",
+          "Colorless",
+          "Colorless"
+        ],
+        "effect": "If you played a Supporter card from your hand during this turn, this attack does 50 more damage."
+      }
+    ],
+    "retreatCost": "2",
+    "weakness": "Psychic",
+    "abilities": [],
+    "evolvesFrom": "Kirlia",
+    "rarity": "Rare EX"
+  },
+  {
+    "id": "b4-085",
+    "name": "Drilbur",
+    "element": "Fighting",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 70,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Mud-Slap",
+        "damage": "20",
+        "cost": [
+          "Fighting"
+        ]
+      }
+    ],
+    "retreatCost": "2",
+    "weakness": "Grass",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Common"
+  },
+  {
+    "id": "b4-086",
+    "name": "Excadrill",
+    "element": "Fighting",
+    "type": "Pokemon",
+    "subtype": "Stage 1",
+    "health": 110,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Mud Shot",
+        "damage": "50",
+        "cost": [
+          "Fighting"
+        ]
+      }
+    ],
+    "retreatCost": "3",
+    "weakness": "Grass",
+    "abilities": [],
+    "evolvesFrom": "Drilbur",
+    "rarity": "Uncommon"
+  },
+  {
+    "id": "b4-087",
+    "name": "Timburr",
+    "element": "Fighting",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 70,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Confront",
+        "damage": "30",
+        "cost": [
+          "Fighting",
+          "Colorless"
+        ]
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Psychic",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Common"
+  },
+  {
+    "id": "b4-088",
+    "name": "Gurdurr",
+    "element": "Fighting",
+    "type": "Pokemon",
+    "subtype": "Stage 1",
+    "health": 90,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Pummel",
+        "damage": "30+",
+        "cost": [
+          "Fighting",
+          "Colorless"
+        ],
+        "effect": "Flip a coin. If heads, this attack does 30 more damage."
+      }
+    ],
+    "retreatCost": "2",
+    "weakness": "Psychic",
+    "abilities": [],
+    "evolvesFrom": "Timburr",
+    "rarity": "Uncommon"
+  },
+  {
+    "id": "b4-089",
+    "name": "Conkeldurr",
+    "element": "Fighting",
+    "type": "Pokemon",
+    "subtype": "Stage 2",
+    "health": 150,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Bedrock Breaker",
+        "damage": "100",
+        "cost": [
+          "Fighting",
+          "Fighting",
+          "Colorless"
+        ],
+        "effect": "Discard a Stadium in play."
+      }
+    ],
+    "retreatCost": "3",
+    "weakness": "Psychic",
+    "abilities": [],
+    "evolvesFrom": "Gurdurr",
+    "rarity": "Rare"
+  },
+  {
+    "id": "b4-090",
+    "name": "Minior",
+    "element": "Fighting",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 70,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Cosmic Tackle",
+        "damage": "10+",
+        "cost": [
+          "Colorless"
+        ],
+        "effect": "If your opponent's Active Pokémon has an Ability, this attack does 40 more damage."
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Grass",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Common"
+  },
+  {
+    "id": "b4-091",
+    "name": "Grimer",
+    "element": "Darkness",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 70,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Gentle Slap",
+        "damage": "20",
+        "cost": [
+          "Darkness"
+        ]
+      }
+    ],
+    "retreatCost": "2",
+    "weakness": "Fighting",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Common"
+  },
+  {
+    "id": "b4-092",
+    "name": "Muk",
+    "element": "Darkness",
+    "type": "Pokemon",
+    "subtype": "Stage 1",
+    "health": 130,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Ambush",
+        "damage": "30+",
+        "cost": [
+          "Darkness"
+        ],
+        "effect": "Flip a coin. If heads, this attack does 30 more damage."
+      }
+    ],
+    "retreatCost": "3",
+    "weakness": "Fighting",
+    "abilities": [],
+    "evolvesFrom": "Grimer",
+    "rarity": "Uncommon"
+  },
+  {
+    "id": "b4-093",
+    "name": "Poochyena",
+    "element": "Darkness",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 60,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Team Hunt",
+        "damage": "",
+        "cost": [
+          "Darkness"
+        ],
+        "effect": "Draw a card for each Poochyena you have in play."
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Grass",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Common"
+  },
+  {
+    "id": "b4-094",
+    "name": "Mightyena",
+    "element": "Darkness",
+    "type": "Pokemon",
+    "subtype": "Stage 1",
+    "health": 90,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Bite",
+        "damage": "50",
+        "cost": [
+          "Darkness"
+        ]
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Grass",
+    "abilities": [],
+    "evolvesFrom": "Poochyena",
+    "rarity": "Common"
+  },
+  {
+    "id": "b4-095",
+    "name": "Galarian Zigzagoon",
+    "element": "Darkness",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 70,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Tackle",
+        "damage": "10",
+        "cost": [
+          "Colorless"
+        ]
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Grass",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Common"
+  },
+  {
+    "id": "b4-096",
+    "name": "Galarian Linoone",
+    "element": "Darkness",
+    "type": "Pokemon",
+    "subtype": "Stage 1",
+    "health": 80,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Night Slash",
+        "damage": "30",
+        "cost": [
+          "Darkness"
+        ],
+        "effect": "Switch this Pokémon with 1 of your Benched Pokémon."
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Grass",
+    "abilities": [],
+    "evolvesFrom": "Galarian Zigzagoon",
+    "rarity": "Uncommon"
+  },
+  {
+    "id": "b4-097",
+    "name": "Galarian Obstagoon",
+    "element": "Darkness",
+    "type": "Pokemon",
+    "subtype": "Stage 2",
+    "health": 140,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Bass Control",
+        "damage": "",
+        "cost": [
+          "Darkness",
+          "Colorless",
+          "Colorless"
+        ],
+        "effect": "This attack does 80 damage to 1 of your opponent's Pokémon."
+      }
+    ],
+    "retreatCost": "2",
+    "weakness": "Grass",
+    "abilities": [],
+    "evolvesFrom": "Galarian Linoone",
+    "rarity": "Rare"
+  },
+  {
+    "id": "b4-098",
+    "name": "Gulpin",
+    "element": "Darkness",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 70,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Sludge Bomb",
+        "damage": "20",
+        "cost": [
+          "Darkness"
+        ]
+      }
+    ],
+    "retreatCost": "2",
+    "weakness": "Fighting",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Common"
+  },
+  {
+    "id": "b4-099",
+    "name": "Swalot",
+    "element": "Darkness",
+    "type": "Pokemon",
+    "subtype": "Stage 1",
+    "health": 120,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Swallow Up",
+        "damage": "30+",
+        "cost": [
+          "Darkness",
+          "Colorless"
+        ],
+        "effect": "If your opponent's Active Pokémon has less remaining HP than this Pokémon, this attack does 80 more damage."
+      }
+    ],
+    "retreatCost": "3",
+    "weakness": "Fighting",
+    "abilities": [],
+    "evolvesFrom": "Gulpin",
+    "rarity": "Uncommon"
+  },
+  {
+    "id": "b4-100",
+    "name": "Absol",
+    "element": "Darkness",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 70,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Enhanced Blade",
+        "damage": "20+",
+        "cost": [
+          "Darkness"
+        ],
+        "effect": "If this Pokémon has a Pokémon Tool attached, this attack does 30 more damage."
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Grass",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Uncommon"
+  },
+  {
+    "id": "b4-101",
+    "name": "Vullaby",
+    "element": "Darkness",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 60,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Run Around",
+        "damage": "",
+        "cost": [
+          "Darkness"
+        ],
+        "effect": "Switch this Pokémon with 1 of your Benched Pokémon."
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Lightning",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Common"
+  },
+  {
+    "id": "b4-102",
+    "name": "Mandibuzz",
+    "element": "Darkness",
+    "type": "Pokemon",
+    "subtype": "Stage 1",
+    "health": 110,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Bone Rush",
+        "damage": "60x",
+        "cost": [
+          "Darkness",
+          "Colorless"
+        ],
+        "effect": "Flip a coin until you get tails. This attack does 60 damage for each heads."
+      }
+    ],
+    "retreatCost": "2",
+    "weakness": "Lightning",
+    "abilities": [],
+    "evolvesFrom": "Vullaby",
+    "rarity": "Uncommon"
+  },
+  {
+    "id": "b4-103",
+    "name": "Hoopa ex",
+    "element": "Darkness",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 150,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Shadow Bullet",
+        "damage": "30",
+        "cost": [
+          "Darkness"
+        ],
+        "effect": "This attack also does 20 damage to 1 of your opponent's Benched Pokémon."
+      },
+      {
+        "name": "Dynamite Punch",
+        "damage": "100",
+        "cost": [
+          "Darkness",
+          "Darkness",
+          "Colorless"
+        ],
+        "effect": "This Pokémon also does 20 damage to itself."
+      }
+    ],
+    "retreatCost": "2",
+    "weakness": "Grass",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Rare EX"
+  },
+  {
+    "id": "b4-104",
+    "name": "Skarmory",
+    "element": "Metal",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 90,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Drill Peck",
+        "damage": "40",
+        "cost": [
+          "Colorless",
+          "Colorless"
+        ]
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Lightning",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Common"
+  },
+  {
+    "id": "b4-105",
+    "name": "Mawile",
+    "element": "Metal",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 80,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Play Rough",
+        "damage": "40+",
+        "cost": [
+          "Metal",
+          "Colorless"
+        ],
+        "effect": "Flip a coin. If heads, this attack does 20 more damage."
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Fire",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Common"
+  },
+  {
+    "id": "b4-106",
+    "name": "Beldum",
+    "element": "Metal",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 60,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Ram",
+        "damage": "10",
+        "cost": [
+          "Metal"
+        ]
+      }
+    ],
+    "retreatCost": "2",
+    "weakness": "Fire",
+    "abilities": [
+      {
+        "name": "Conductive Body",
+        "effect": "If you have another Beldum in play, this Pokémon's Retreat Cost is 2 less."
+      }
+    ],
+    "evolvesFrom": null,
+    "rarity": "Common"
+  },
+  {
+    "id": "b4-107",
+    "name": "Metang",
+    "element": "Metal",
+    "type": "Pokemon",
+    "subtype": "Stage 1",
+    "health": 100,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Bullet Punch",
+        "damage": "30+",
+        "cost": [
+          "Metal",
+          "Colorless"
+        ],
+        "effect": "Flip 2 coins. This attack does 20 more damage for each heads."
+      }
+    ],
+    "retreatCost": "3",
+    "weakness": "Fire",
+    "abilities": [],
+    "evolvesFrom": "Beldum",
+    "rarity": "Uncommon"
+  },
+  {
+    "id": "b4-108",
+    "name": "Metagross",
+    "element": "Metal",
+    "type": "Pokemon",
+    "subtype": "Stage 2",
+    "health": 160,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Squared Attack",
+        "damage": "50x",
+        "cost": [
+          "Metal",
+          "Colorless",
+          "Colorless"
+        ],
+        "effect": "Flip 4 coins. This attack does 50 damage for each heads."
+      }
+    ],
+    "retreatCost": "3",
+    "weakness": "Fire",
+    "abilities": [],
+    "evolvesFrom": "Metang",
+    "rarity": "Rare"
+  },
+  {
+    "id": "b4-109",
+    "name": "Mega Metagross ex",
+    "element": "Metal",
+    "type": "Pokemon",
+    "subtype": "Stage 2",
+    "health": 230,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Gatling Slug",
+        "damage": "100+",
+        "cost": [
+          "Colorless",
+          "Colorless",
+          "Colorless"
+        ],
+        "effect": "This attack does 10 more damage for each Metal Energy attached to this Pokémon."
+      }
+    ],
+    "retreatCost": "3",
+    "weakness": "Fire",
+    "abilities": [],
+    "evolvesFrom": "Metang",
+    "rarity": "Rare EX"
+  },
+  {
+    "id": "b4-110",
+    "name": "Escavalier",
+    "element": "Metal",
+    "type": "Pokemon",
+    "subtype": "Stage 1",
+    "health": 120,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Iron Lance",
+        "damage": "70",
+        "cost": [
+          "Metal",
+          "Metal"
+        ]
+      }
+    ],
+    "retreatCost": "3",
+    "weakness": "Fire",
+    "abilities": [],
+    "evolvesFrom": "Karrablast",
+    "rarity": "Uncommon"
+  },
+  {
+    "id": "b4-111",
+    "name": "Genesect",
+    "element": "Metal",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 100,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Techno Blast",
+        "damage": "70",
+        "cost": [
+          "Metal",
+          "Metal"
+        ],
+        "effect": "During your next turn, this Pokémon can't attack."
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Fire",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Rare"
+  },
+  {
+    "id": "b4-112",
+    "name": "Duraludon",
+    "element": "Metal",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 110,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Metal Claw",
+        "damage": "60",
+        "cost": [
+          "Metal",
+          "Metal",
+          "Colorless"
+        ]
+      }
+    ],
+    "retreatCost": "3",
+    "weakness": "Fire",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Uncommon"
+  },
+  {
+    "id": "b4-113",
+    "name": "Archaludon",
+    "element": "Metal",
+    "type": "Pokemon",
+    "subtype": "Stage 1",
+    "health": 140,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Raging Blade",
+        "damage": "80+",
+        "cost": [
+          "Metal",
+          "Metal",
+          "Colorless",
+          "Colorless"
+        ],
+        "effect": "If this Pokémon has damage on it, this attack does 80 more damage."
+      }
+    ],
+    "retreatCost": "3",
+    "weakness": "Fire",
+    "abilities": [],
+    "evolvesFrom": "Duraludon",
+    "rarity": "Rare"
+  },
+  {
+    "id": "b4-114",
+    "name": "Varoom",
+    "element": "Metal",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 70,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Headbutt Bounce",
+        "damage": "30",
+        "cost": [
+          "Metal",
+          "Colorless"
+        ]
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Fire",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Common"
+  },
+  {
+    "id": "b4-115",
+    "name": "Revavroom",
+    "element": "Metal",
+    "type": "Pokemon",
+    "subtype": "Stage 1",
+    "health": 120,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Overacceleration",
+        "damage": "70",
+        "cost": [
+          "Metal",
+          "Metal",
+          "Colorless",
+          "Colorless"
+        ],
+        "effect": "During your next turn, this Pokémon's Overacceleration attack does +70 damage."
+      }
+    ],
+    "retreatCost": "2",
+    "weakness": "Fire",
+    "abilities": [
+      {
+        "name": "Dual Customization",
+        "effect": "This Pokémon may have up to 2 Pokémon Tool cards attached to it."
+      }
+    ],
+    "evolvesFrom": "Varoom",
+    "rarity": "Rare"
+  },
+  {
+    "id": "b4-116",
+    "name": "Dratini",
+    "element": "Dragon",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 60,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Slam",
+        "damage": "20x",
+        "cost": [
+          "Colorless"
+        ],
+        "effect": "Flip 2 coins. This attack does 20 damage for each heads."
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": null,
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Common"
+  },
+  {
+    "id": "b4-117",
+    "name": "Dragonair",
+    "element": "Dragon",
+    "type": "Pokemon",
+    "subtype": "Stage 1",
+    "health": 80,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Draconic Whip",
+        "damage": "40",
+        "cost": [
+          "Colorless",
+          "Colorless"
+        ]
+      }
+    ],
+    "retreatCost": "2",
+    "weakness": null,
+    "abilities": [
+      {
+        "name": "Dragon’s Blessing",
+        "effect": "Once during your turn, if this Pokémon is on your Bench, you may attach an Energy from your discard pile to your Active Dragon Pokémon."
+      }
+    ],
+    "evolvesFrom": "Dratini",
+    "rarity": "Uncommon"
+  },
+  {
+    "id": "b4-118",
+    "name": "Dragonite",
+    "element": "Dragon",
+    "type": "Pokemon",
+    "subtype": "Stage 2",
+    "health": 150,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Hyper Beam",
+        "damage": "110",
+        "cost": [
+          "Water",
+          "Lightning",
+          "Colorless"
+        ],
+        "effect": "Discard a random Energy from your opponent's Active Pokémon."
+      }
+    ],
+    "retreatCost": "3",
+    "weakness": null,
+    "abilities": [],
+    "evolvesFrom": "Dragonair",
+    "rarity": "Rare"
+  },
+  {
+    "id": "b4-119",
+    "name": "Rayquaza",
+    "element": "Dragon",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 120,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Dragon Impact",
+        "damage": "140",
+        "cost": [
+          "Fire",
+          "Lightning",
+          "Colorless",
+          "Colorless"
+        ],
+        "effect": "Discard 2 random Energy from this Pokémon."
+      }
+    ],
+    "retreatCost": "2",
+    "weakness": null,
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Rare"
+  },
+  {
+    "id": "b4-120",
+    "name": "Mega Rayquaza ex",
+    "element": "Dragon",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 180,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Mega Burst",
+        "damage": "50x",
+        "cost": [
+          "Fire",
+          "Lightning"
+        ],
+        "effect": "Discard all Fire and Lightning Energy from this Pokémon, and this attack does 50 damage for each Energy you discarded in this way."
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": null,
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Rare EX"
+  },
+  {
+    "id": "b4-121",
+    "name": "Noibat",
+    "element": "Dragon",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 60,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Wing Attack",
+        "damage": "40",
+        "cost": [
+          "Psychic",
+          "Darkness"
+        ]
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": null,
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Common"
+  },
+  {
+    "id": "b4-122",
+    "name": "Noivern",
+    "element": "Dragon",
+    "type": "Pokemon",
+    "subtype": "Stage 1",
+    "health": 100,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Draco Meteor",
+        "damage": "",
+        "cost": [
+          "Psychic",
+          "Darkness",
+          "Darkness"
+        ],
+        "effect": "1 of your opponent's Pokémon is chosen at random 3 times. For each time a Pokémon was chosen, do 60 damage to it."
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": null,
+    "abilities": [],
+    "evolvesFrom": "Noibat",
+    "rarity": "Rare"
+  },
+  {
+    "id": "b4-123",
+    "name": "Turtonator",
+    "element": "Dragon",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 110,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Searing Flame",
+        "damage": "70",
+        "cost": [
+          "Fire",
+          "Fighting",
+          "Colorless"
+        ],
+        "effect": "Your opponent's Active Pokémon is now Burned."
+      }
+    ],
+    "retreatCost": "3",
+    "weakness": null,
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Uncommon"
+  },
+  {
+    "id": "b4-124",
+    "name": "Drampa",
+    "element": "Dragon",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 100,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Power Blast",
+        "damage": "70",
+        "cost": [
+          "Colorless",
+          "Colorless"
+        ],
+        "effect": "Discard a random Energy from this Pokémon."
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": null,
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Uncommon"
+  },
+  {
+    "id": "b4-125",
+    "name": "Applin",
+    "element": "Dragon",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 40,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Rolling Tackle",
+        "damage": "40",
+        "cost": [
+          "Grass",
+          "Fire"
+        ]
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": null,
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Common"
+  },
+  {
+    "id": "b4-126",
+    "name": "Dipplin",
+    "element": "Dragon",
+    "type": "Pokemon",
+    "subtype": "Stage 1",
+    "health": 80,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Double Hit",
+        "damage": "60x",
+        "cost": [
+          "Grass",
+          "Fire"
+        ],
+        "effect": "Flip 2 coins. This attack does 60 damage for each heads."
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": null,
+    "abilities": [],
+    "evolvesFrom": "Applin",
+    "rarity": "Uncommon"
+  },
+  {
+    "id": "b4-127",
+    "name": "Hydrapple",
+    "element": "Dragon",
+    "type": "Pokemon",
+    "subtype": "Stage 2",
+    "health": 150,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Fickle Beam",
+        "damage": "100+",
+        "cost": [
+          "Grass",
+          "Fire"
+        ],
+        "effect": "Flip 2 coins. If both of them are heads, this attack does 100 more damage."
+      }
+    ],
+    "retreatCost": "2",
+    "weakness": null,
+    "abilities": [],
+    "evolvesFrom": "Dipplin",
+    "rarity": "Rare"
+  },
+  {
+    "id": "b4-128",
+    "name": "Cyclizar",
+    "element": "Dragon",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 90,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Acceleration Drive",
+        "damage": "70",
+        "cost": [
+          "Grass",
+          "Darkness",
+          "Colorless"
+        ],
+        "effect": "Flip a coin. If heads, during your opponent's next turn, prevent all damage from—and effects of—attacks done to this Pokémon."
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": null,
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Uncommon"
+  },
+  {
+    "id": "b4-129",
+    "name": "Rattata",
+    "element": "Colorless",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 50,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Surprise Attack",
+        "damage": "40",
+        "cost": [
+          "Colorless"
+        ],
+        "effect": "Flip a coin. If tails, this attack does nothing."
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Fighting",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Common"
+  },
+  {
+    "id": "b4-130",
+    "name": "Raticate",
+    "element": "Colorless",
+    "type": "Pokemon",
+    "subtype": "Stage 1",
+    "health": 80,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Speed Attack",
+        "damage": "40",
+        "cost": [
+          "Colorless",
+          "Colorless"
+        ]
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Fighting",
+    "abilities": [
+      {
+        "name": "Treasure Collecting",
+        "effect": "Once during your turn, when you play this Pokémon from your hand to evolve 1 of your Pokémon, you may look at the top 4 cards of your deck and put all Item cards you find there into your hand. Shuffle the other cards back into your deck."
+      }
+    ],
+    "evolvesFrom": "Rattata",
+    "rarity": "Rare"
+  },
+  {
+    "id": "b4-131",
+    "name": "Eevee",
+    "element": "Colorless",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 60,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Tail Rap",
+        "damage": "20x",
+        "cost": [
+          "Colorless"
+        ],
+        "effect": "Flip 2 coins. This attack does 20 damage for each heads."
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Fighting",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Common"
+  },
+  {
+    "id": "b4-132",
+    "name": "Aipom",
+    "element": "Colorless",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 60,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Playful Kick",
+        "damage": "40",
+        "cost": [
+          "Colorless",
+          "Colorless"
+        ]
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Fighting",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Common"
+  },
+  {
+    "id": "b4-133",
+    "name": "Ambipom",
+    "element": "Colorless",
+    "type": "Pokemon",
+    "subtype": "Stage 1",
+    "health": 90,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Smack",
+        "damage": "60",
+        "cost": [
+          "Colorless",
+          "Colorless"
+        ]
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Fighting",
+    "abilities": [],
+    "evolvesFrom": "Aipom",
+    "rarity": "Common"
+  },
+  {
+    "id": "b4-134",
+    "name": "Skitty",
+    "element": "Colorless",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 60,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Charm",
+        "damage": "",
+        "cost": [
+          "Colorless"
+        ],
+        "effect": "During your opponent's next turn, attacks used by the Defending Pokémon do −20 damage."
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Fighting",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Common"
+  },
+  {
+    "id": "b4-135",
+    "name": "Delcatty",
+    "element": "Colorless",
+    "type": "Pokemon",
+    "subtype": "Stage 1",
+    "health": 90,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Energy Blender",
+        "damage": "50",
+        "cost": [
+          "Colorless",
+          "Colorless"
+        ],
+        "effect": "You may move any amount of Energy from your Pokémon in play to your other Pokémon in any way you like."
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Fighting",
+    "abilities": [],
+    "evolvesFrom": "Skitty",
+    "rarity": "Uncommon"
+  },
+  {
+    "id": "b4-136",
+    "name": "Kecleon",
+    "element": "Colorless",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 80,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Samesies Slap",
+        "damage": "20+",
+        "cost": [
+          "Colorless"
+        ],
+        "effect": "If this Pokémon and your opponent's Active Pokémon have 1 or more of the same type of Energy attached, this attack does 30 more damage."
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Fighting",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Common"
+  },
+  {
+    "id": "b4-137",
+    "name": "Pidove",
+    "element": "Colorless",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 60,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Gust",
+        "damage": "20",
+        "cost": [
+          "Colorless"
+        ]
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Lightning",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Common"
+  },
+  {
+    "id": "b4-138",
+    "name": "Tranquill",
+    "element": "Colorless",
+    "type": "Pokemon",
+    "subtype": "Stage 1",
+    "health": 80,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Speed Dive",
+        "damage": "40",
+        "cost": [
+          "Colorless"
+        ]
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Lightning",
+    "abilities": [],
+    "evolvesFrom": "Pidove",
+    "rarity": "Common"
+  },
+  {
+    "id": "b4-139",
+    "name": "Unfezant",
+    "element": "Colorless",
+    "type": "Pokemon",
+    "subtype": "Stage 2",
+    "health": 130,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Fly",
+        "damage": "90",
+        "cost": [
+          "Colorless",
+          "Colorless"
+        ],
+        "effect": "Flip a coin. If tails, this attack does nothing. If heads, during your opponent's next turn, prevent all damage from—and effects of—attacks done to this Pokémon."
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Lightning",
+    "abilities": [],
+    "evolvesFrom": "Tranquill",
+    "rarity": "Uncommon"
+  },
+  {
+    "id": "b4-140",
+    "name": "Ducklett",
+    "element": "Colorless",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 60,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Wing Attack",
+        "damage": "30",
+        "cost": [
+          "Colorless",
+          "Colorless"
+        ]
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Lightning",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Common"
+  },
+  {
+    "id": "b4-141",
+    "name": "Swanna ex",
+    "element": "Colorless",
+    "type": "Pokemon",
+    "subtype": "Stage 1",
+    "health": 150,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Jet Wing",
+        "damage": "140",
+        "cost": [
+          "Colorless",
+          "Colorless",
+          "Colorless"
+        ],
+        "effect": "During your next turn, this Pokémon can't attack."
+      }
+    ],
+    "retreatCost": "2",
+    "weakness": "Lightning",
+    "abilities": [],
+    "evolvesFrom": "Ducklett",
+    "rarity": "Rare EX"
+  },
+  {
+    "id": "b4-142",
+    "name": "Furfrou",
+    "element": "Colorless",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 70,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Retaliate",
+        "damage": "20+",
+        "cost": [
+          "Colorless"
+        ],
+        "effect": "If any of your Pokémon were Knocked Out by damage from an attack during your opponent's last turn, this attack does 50 more damage."
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Fighting",
+    "abilities": [
+      {
+        "name": "Fur Coat",
+        "effect": "This Pokémon takes −20 damage from attacks."
+      }
+    ],
+    "evolvesFrom": null,
+    "rarity": "Uncommon"
+  },
+  {
+    "id": "b4-143",
+    "name": "Type: Null",
+    "element": "Colorless",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 80,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Tackle",
+        "damage": "40",
+        "cost": [
+          "Colorless",
+          "Colorless"
+        ]
+      }
+    ],
+    "retreatCost": "2",
+    "weakness": "Fighting",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Uncommon"
+  },
+  {
+    "id": "b4-144",
+    "name": "Silvally",
+    "element": "Colorless",
+    "type": "Pokemon",
+    "subtype": "Stage 1",
+    "health": 110,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Gold Breaker",
+        "damage": "60+",
+        "cost": [
+          "Colorless",
+          "Colorless",
+          "Colorless"
+        ],
+        "effect": "If your opponent's Active Pokémon is a Pokémon ex, this attack does 90 more damage."
+      }
+    ],
+    "retreatCost": "2",
+    "weakness": "Fighting",
+    "abilities": [],
+    "evolvesFrom": "Type: Null",
+    "rarity": "Rare"
+  },
+  {
+    "id": "b4-145",
+    "name": "Order Pad",
+    "element": null,
+    "type": "Trainer",
+    "subtype": "Item",
+    "health": null,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [],
+    "retreatCost": null,
+    "weakness": null,
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Uncommon"
+  },
+  {
+    "id": "b4-146",
+    "name": "Claw Fossil",
+    "element": null,
+    "type": "Trainer",
+    "subtype": "Item",
+    "health": null,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [],
+    "retreatCost": null,
+    "weakness": null,
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Common"
+  },
+  {
+    "id": "b4-147",
+    "name": "Root Fossil",
+    "element": null,
+    "type": "Trainer",
+    "subtype": "Item",
+    "health": null,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [],
+    "retreatCost": null,
+    "weakness": null,
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Common"
+  },
+  {
+    "id": "b4-148",
+    "name": "Deceptive Needle",
+    "element": null,
+    "type": "Trainer",
+    "subtype": "Tool",
+    "health": null,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [],
+    "retreatCost": null,
+    "weakness": null,
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Uncommon"
+  },
+  {
+    "id": "b4-149",
+    "name": "Clear Veil",
+    "element": null,
+    "type": "Trainer",
+    "subtype": "Tool",
+    "health": null,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [],
+    "retreatCost": null,
+    "weakness": null,
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Uncommon"
+  },
+  {
+    "id": "b4-150",
+    "name": "Psychic",
+    "element": null,
+    "type": "Trainer",
+    "subtype": "Supporter",
+    "health": null,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [],
+    "retreatCost": null,
+    "weakness": null,
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Uncommon"
+  },
+  {
+    "id": "b4-151",
+    "name": "Drayden",
+    "element": null,
+    "type": "Trainer",
+    "subtype": "Supporter",
+    "health": null,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [],
+    "retreatCost": null,
+    "weakness": null,
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Uncommon"
+  },
+  {
+    "id": "b4-152",
+    "name": "Skyla",
+    "element": null,
+    "type": "Trainer",
+    "subtype": "Supporter",
+    "health": null,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [],
+    "retreatCost": null,
+    "weakness": null,
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Uncommon"
+  },
+  {
+    "id": "b4-153",
+    "name": "Wally",
+    "element": null,
+    "type": "Trainer",
+    "subtype": "Supporter",
+    "health": null,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [],
+    "retreatCost": null,
+    "weakness": null,
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Uncommon"
+  },
+  {
+    "id": "b4-154",
+    "name": "Soothing Shore",
+    "element": null,
+    "type": "Trainer",
+    "subtype": "Stadium",
+    "health": null,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [],
+    "retreatCost": null,
+    "weakness": null,
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Uncommon"
+  },
+  {
+    "id": "b4-155",
+    "name": "Rainbow Cave",
+    "element": null,
+    "type": "Trainer",
+    "subtype": "Stadium",
+    "health": null,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [],
+    "retreatCost": null,
+    "weakness": null,
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Uncommon"
+  },
+  {
+    "id": "b4-156",
+    "name": "Wurmple",
+    "element": "Grass",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 60,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Gnaw",
+        "damage": "10",
+        "cost": [
+          "Colorless"
+        ]
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Fire",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Full Art"
+  },
+  {
+    "id": "b4-157",
+    "name": "Lileep",
+    "element": "Grass",
+    "type": "Pokemon",
+    "subtype": "Stage 1",
+    "health": 90,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Blot",
+        "damage": "40",
+        "cost": [
+          "Grass"
+        ],
+        "effect": "Heal 10 damage from this Pokémon."
+      }
+    ],
+    "retreatCost": "2",
+    "weakness": "Fire",
+    "abilities": [],
+    "evolvesFrom": "Root Fossil",
+    "rarity": "Full Art"
+  },
+  {
+    "id": "b4-158",
+    "name": "Kricketune",
+    "element": "Grass",
+    "type": "Pokemon",
+    "subtype": "Stage 1",
+    "health": 90,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Bug Buzz",
+        "damage": "50",
+        "cost": [
+          "Grass"
+        ]
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Fire",
+    "abilities": [],
+    "evolvesFrom": "Kricketot",
+    "rarity": "Full Art"
+  },
+  {
+    "id": "b4-159",
+    "name": "Accelgor",
+    "element": "Grass",
+    "type": "Pokemon",
+    "subtype": "Stage 1",
+    "health": 80,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Deck and Cover",
+        "damage": "50",
+        "cost": [
+          "Colorless",
+          "Colorless"
+        ],
+        "effect": "Your opponent's Active Pokémon is now Poisoned and Paralyzed. Shuffle this Pokémon and all attached cards into your deck."
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Fire",
+    "abilities": [],
+    "evolvesFrom": "Shelmet",
+    "rarity": "Full Art"
+  },
+  {
+    "id": "b4-160",
+    "name": "Ponyta",
+    "element": "Fire",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 60,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Stoke",
+        "damage": "",
+        "cost": [
+          "Fire"
+        ],
+        "effect": "Take a Fire Energy from your Energy Zone and attach it to this Pokémon."
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Water",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Full Art"
+  },
+  {
+    "id": "b4-161",
+    "name": "Quilava",
+    "element": "Fire",
+    "type": "Pokemon",
+    "subtype": "Stage 1",
+    "health": 80,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Heat Wave",
+        "damage": "30",
+        "cost": [
+          "Fire",
+          "Fire"
+        ],
+        "effect": "Your opponent's Active Pokémon is now Burned."
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Water",
+    "abilities": [],
+    "evolvesFrom": "Cyndaquil",
+    "rarity": "Full Art"
+  },
+  {
+    "id": "b4-162",
+    "name": "Kyogre",
+    "element": "Water",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 120,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Tidal Blast",
+        "damage": "",
+        "cost": [
+          "Water",
+          "Water",
+          "Water",
+          "Water"
+        ],
+        "effect": "Discard 3 Water Energy from this Pokémon, and this attack does 50 damage to each of your opponent's Pokémon."
+      }
+    ],
+    "retreatCost": "2",
+    "weakness": "Lightning",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Full Art"
+  },
+  {
+    "id": "b4-163",
+    "name": "Samurott",
+    "element": "Water",
+    "type": "Pokemon",
+    "subtype": "Stage 2",
+    "health": 150,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Pike",
+        "damage": "60",
+        "cost": [
+          "Water",
+          "Water"
+        ],
+        "effect": "This attack also does 20 damage to 1 of your opponent's Benched Pokémon."
+      }
+    ],
+    "retreatCost": "2",
+    "weakness": "Lightning",
+    "abilities": [
+      {
+        "name": "Stance",
+        "effect": "Once during your turn, when you play this Pokémon from your hand to evolve 1 of your Pokémon, you may prevent all damage from—and effects of—attacks from your opponent's Pokémon done to this Pokémon until the end of your opponent's next turn."
+      }
+    ],
+    "evolvesFrom": "Dewott",
+    "rarity": "Full Art"
+  },
+  {
+    "id": "b4-164",
+    "name": "Raichu",
+    "element": "Lightning",
+    "type": "Pokemon",
+    "subtype": "Stage 1",
+    "health": 100,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Electro Ball",
+        "damage": "50",
+        "cost": [
+          "Lightning",
+          "Colorless"
+        ]
+      }
+    ],
+    "retreatCost": "2",
+    "weakness": "Fighting",
+    "abilities": [
+      {
+        "name": "Evoshock",
+        "effect": "Once during your turn, when you play this Pokémon from your hand to evolve 1 of your Pokémon, you may flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+      }
+    ],
+    "evolvesFrom": "Pikachu",
+    "rarity": "Full Art"
+  },
+  {
+    "id": "b4-165",
+    "name": "Wattrel",
+    "element": "Lightning",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 60,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Peck",
+        "damage": "10",
+        "cost": [
+          "Colorless"
+        ]
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Lightning",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Full Art"
+  },
+  {
+    "id": "b4-166",
+    "name": "Clefairy",
+    "element": "Psychic",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 60,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Mini-Metronome",
+        "damage": "",
+        "cost": [
+          "Colorless",
+          "Colorless",
+          "Colorless"
+        ],
+        "effect": "Flip a coin. If heads, choose 1 of your opponent's Active Pokémon's attacks and use it as this attack."
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Metal",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Full Art"
+  },
+  {
+    "id": "b4-167",
+    "name": "Ralts",
+    "element": "Psychic",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 60,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Lead",
+        "damage": "",
+        "cost": [
+          "Colorless"
+        ],
+        "effect": "Put a random Supporter card from your deck into your hand."
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Darkness",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Full Art"
+  },
+  {
+    "id": "b4-168",
+    "name": "Wynaut",
+    "element": "Psychic",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 30,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Stompy Jammer",
+        "damage": "10",
+        "cost": [],
+        "effect": "During your opponent's next turn, attacks used by the Defending Pokémon cost 1 Colorless more."
+      }
+    ],
+    "retreatCost": "0",
+    "weakness": null,
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Full Art"
+  },
+  {
+    "id": "b4-169",
+    "name": "Oricorio",
+    "element": "Psychic",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 80,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Supernatural Feather",
+        "damage": "50",
+        "cost": [
+          "Psychic"
+        ],
+        "effect": "Discard a card from your hand. If you can't, this attack does nothing."
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Darkness",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Full Art"
+  },
+  {
+    "id": "b4-170",
+    "name": "Anorith",
+    "element": "Fighting",
+    "type": "Pokemon",
+    "subtype": "Stage 1",
+    "health": 90,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Slash",
+        "damage": "40",
+        "cost": [
+          "Fighting"
+        ]
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Grass",
+    "abilities": [],
+    "evolvesFrom": "Claw Fossil",
+    "rarity": "Full Art"
+  },
+  {
+    "id": "b4-171",
+    "name": "Poochyena",
+    "element": "Darkness",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 60,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Team Hunt",
+        "damage": "",
+        "cost": [
+          "Darkness"
+        ],
+        "effect": "Draw a card for each Poochyena you have in play."
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Grass",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Full Art"
+  },
+  {
+    "id": "b4-172",
+    "name": "Gulpin",
+    "element": "Darkness",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 70,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Sludge Bomb",
+        "damage": "20",
+        "cost": [
+          "Darkness"
+        ]
+      }
+    ],
+    "retreatCost": "2",
+    "weakness": "Fighting",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Full Art"
+  },
+  {
+    "id": "b4-173",
+    "name": "Vullaby",
+    "element": "Darkness",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 60,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Run Around",
+        "damage": "",
+        "cost": [
+          "Darkness"
+        ],
+        "effect": "Switch this Pokémon with 1 of your Benched Pokémon."
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Lightning",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Full Art"
+  },
+  {
+    "id": "b4-174",
+    "name": "Genesect",
+    "element": "Metal",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 100,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Techno Blast",
+        "damage": "70",
+        "cost": [
+          "Metal",
+          "Metal"
+        ],
+        "effect": "During your next turn, this Pokémon can't attack."
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Fire",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Full Art"
+  },
+  {
+    "id": "b4-175",
+    "name": "Dragonair",
+    "element": "Dragon",
+    "type": "Pokemon",
+    "subtype": "Stage 1",
+    "health": 80,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Draconic Whip",
+        "damage": "40",
+        "cost": [
+          "Colorless",
+          "Colorless"
+        ]
+      }
+    ],
+    "retreatCost": "2",
+    "weakness": null,
+    "abilities": [
+      {
+        "name": "Dragon’s Blessing",
+        "effect": "Once during your turn, if this Pokémon is on your Bench, you may attach an Energy from your discard pile to your Active Dragon Pokémon."
+      }
+    ],
+    "evolvesFrom": "Dratini",
+    "rarity": "Full Art"
+  },
+  {
+    "id": "b4-176",
+    "name": "Noivern",
+    "element": "Dragon",
+    "type": "Pokemon",
+    "subtype": "Stage 1",
+    "health": 100,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Draco Meteor",
+        "damage": "",
+        "cost": [
+          "Psychic",
+          "Darkness",
+          "Darkness"
+        ],
+        "effect": "1 of your opponent's Pokémon is chosen at random 3 times. For each time a Pokémon was chosen, do 60 damage to it."
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": null,
+    "abilities": [],
+    "evolvesFrom": "Noibat",
+    "rarity": "Full Art"
+  },
+  {
+    "id": "b4-177",
+    "name": "Cyclizar",
+    "element": "Dragon",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 90,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Acceleration Drive",
+        "damage": "70",
+        "cost": [
+          "Grass",
+          "Darkness",
+          "Colorless"
+        ],
+        "effect": "Flip a coin. If heads, during your opponent's next turn, prevent all damage from—and effects of—attacks done to this Pokémon."
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": null,
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Full Art"
+  },
+  {
+    "id": "b4-178",
+    "name": "Raticate",
+    "element": "Colorless",
+    "type": "Pokemon",
+    "subtype": "Stage 1",
+    "health": 80,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Speed Attack",
+        "damage": "40",
+        "cost": [
+          "Colorless",
+          "Colorless"
+        ]
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Fighting",
+    "abilities": [
+      {
+        "name": "Treasure Collecting",
+        "effect": "Once during your turn, when you play this Pokémon from your hand to evolve 1 of your Pokémon, you may look at the top 4 cards of your deck and put all Item cards you find there into your hand. Shuffle the other cards back into your deck."
+      }
+    ],
+    "evolvesFrom": "Rattata",
+    "rarity": "Full Art"
+  },
+  {
+    "id": "b4-179",
+    "name": "Aipom",
+    "element": "Colorless",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 60,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Playful Kick",
+        "damage": "40",
+        "cost": [
+          "Colorless",
+          "Colorless"
+        ]
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Fighting",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Full Art"
+  },
+  {
+    "id": "b4-180",
+    "name": "Vespiquen ex",
+    "element": "Grass",
+    "type": "Pokemon",
+    "subtype": "Stage 1",
+    "health": 140,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Chase Order",
+        "damage": "70+",
+        "cost": [
+          "Grass",
+          "Grass"
+        ],
+        "effect": "You may discard 1 of your Benched Basic Grass Pokémon. If you do, this attack does 70 more damage."
+      }
+    ],
+    "retreatCost": "2",
+    "weakness": "Fire",
+    "abilities": [],
+    "evolvesFrom": "Combee",
+    "rarity": "Full Art EX/Support"
+  },
+  {
+    "id": "b4-181",
+    "name": "Typhlosion ex",
+    "element": "Fire",
+    "type": "Pokemon",
+    "subtype": "Stage 2",
+    "health": 180,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Destructive Inferno",
+        "damage": "110",
+        "cost": [
+          "Fire",
+          "Fire",
+          "Colorless"
+        ],
+        "effect": "Flip a coin until you get tails. For each heads, discard a random Energy from your opponent's Active Pokémon."
+      }
+    ],
+    "retreatCost": "2",
+    "weakness": "Water",
+    "abilities": [],
+    "evolvesFrom": "Quilava",
+    "rarity": "Full Art EX/Support"
+  },
+  {
+    "id": "b4-182",
+    "name": "Mega Sharpedo ex",
+    "element": "Water",
+    "type": "Pokemon",
+    "subtype": "Stage 1",
+    "health": 190,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Turbo Shark",
+        "damage": "70",
+        "cost": [
+          "Water"
+        ],
+        "effect": "Take a Water Energy from your Energy Zone and attach it to 1 of your Benched Water Pokémon."
+      }
+    ],
+    "retreatCost": "0",
+    "weakness": "Lightning",
+    "abilities": [],
+    "evolvesFrom": "Carvanha",
+    "rarity": "Full Art EX/Support"
+  },
+  {
+    "id": "b4-183",
+    "name": "Wailord ex",
+    "element": "Water",
+    "type": "Pokemon",
+    "subtype": "Stage 1",
+    "health": 250,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Wondrous Waves",
+        "damage": "100",
+        "cost": [
+          "Water",
+          "Water",
+          "Water",
+          "Water"
+        ],
+        "effect": "This Pokémon recovers from all Special Conditions."
+      }
+    ],
+    "retreatCost": "4",
+    "weakness": "Lightning",
+    "abilities": [],
+    "evolvesFrom": "Wailmer",
+    "rarity": "Full Art EX/Support"
+  },
+  {
+    "id": "b4-184",
+    "name": "Rotom ex",
+    "element": "Lightning",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 120,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Junk Spark",
+        "damage": "30+",
+        "cost": [
+          "Lightning",
+          "Lightning"
+        ],
+        "effect": "This attack does 10 more damage for each Item card in your discard pile."
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Fighting",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Full Art EX/Support"
+  },
+  {
+    "id": "b4-185",
+    "name": "Mega Gallade ex",
+    "element": "Fighting",
+    "type": "Pokemon",
+    "subtype": "Stage 2",
+    "health": 220,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Resonating Blade",
+        "damage": "100+",
+        "cost": [
+          "Fighting",
+          "Colorless",
+          "Colorless"
+        ],
+        "effect": "If you played a Supporter card from your hand during this turn, this attack does 50 more damage."
+      }
+    ],
+    "retreatCost": "2",
+    "weakness": "Psychic",
+    "abilities": [],
+    "evolvesFrom": "Kirlia",
+    "rarity": "Full Art EX/Support"
+  },
+  {
+    "id": "b4-186",
+    "name": "Hoopa ex",
+    "element": "Darkness",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 150,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Shadow Bullet",
+        "damage": "30",
+        "cost": [
+          "Darkness"
+        ],
+        "effect": "This attack also does 20 damage to 1 of your opponent's Benched Pokémon."
+      },
+      {
+        "name": "Dynamite Punch",
+        "damage": "100",
+        "cost": [
+          "Darkness",
+          "Darkness",
+          "Colorless"
+        ],
+        "effect": "This Pokémon also does 20 damage to itself."
+      }
+    ],
+    "retreatCost": "2",
+    "weakness": "Grass",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Full Art EX/Support"
+  },
+  {
+    "id": "b4-187",
+    "name": "Mega Metagross ex",
+    "element": "Metal",
+    "type": "Pokemon",
+    "subtype": "Stage 2",
+    "health": 230,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Gatling Slug",
+        "damage": "100+",
+        "cost": [
+          "Colorless",
+          "Colorless",
+          "Colorless"
+        ],
+        "effect": "This attack does 10 more damage for each Metal Energy attached to this Pokémon."
+      }
+    ],
+    "retreatCost": "3",
+    "weakness": "Fire",
+    "abilities": [],
+    "evolvesFrom": "Metang",
+    "rarity": "Full Art EX/Support"
+  },
+  {
+    "id": "b4-188",
+    "name": "Mega Rayquaza ex",
+    "element": "Dragon",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 180,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Mega Burst",
+        "damage": "50x",
+        "cost": [
+          "Fire",
+          "Lightning"
+        ],
+        "effect": "Discard all Fire and Lightning Energy from this Pokémon, and this attack does 50 damage for each Energy you discarded in this way."
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": null,
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Full Art EX/Support"
+  },
+  {
+    "id": "b4-189",
+    "name": "Swanna ex",
+    "element": "Colorless",
+    "type": "Pokemon",
+    "subtype": "Stage 1",
+    "health": 150,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Jet Wing",
+        "damage": "140",
+        "cost": [
+          "Colorless",
+          "Colorless",
+          "Colorless"
+        ],
+        "effect": "During your next turn, this Pokémon can't attack."
+      }
+    ],
+    "retreatCost": "2",
+    "weakness": "Lightning",
+    "abilities": [],
+    "evolvesFrom": "Ducklett",
+    "rarity": "Full Art EX/Support"
+  },
+  {
+    "id": "b4-190",
+    "name": "Psychic",
+    "element": null,
+    "type": "Trainer",
+    "subtype": "Supporter",
+    "health": null,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [],
+    "retreatCost": null,
+    "weakness": null,
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Full Art EX/Support"
+  },
+  {
+    "id": "b4-191",
+    "name": "Drayden",
+    "element": null,
+    "type": "Trainer",
+    "subtype": "Supporter",
+    "health": null,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [],
+    "retreatCost": null,
+    "weakness": null,
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Full Art EX/Support"
+  },
+  {
+    "id": "b4-192",
+    "name": "Skyla",
+    "element": null,
+    "type": "Trainer",
+    "subtype": "Supporter",
+    "health": null,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [],
+    "retreatCost": null,
+    "weakness": null,
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Full Art EX/Support"
+  },
+  {
+    "id": "b4-193",
+    "name": "Wally",
+    "element": null,
+    "type": "Trainer",
+    "subtype": "Supporter",
+    "health": null,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [],
+    "retreatCost": null,
+    "weakness": null,
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Full Art EX/Support"
+  },
+  {
+    "id": "b4-194",
+    "name": "Vespiquen ex",
+    "element": "Grass",
+    "type": "Pokemon",
+    "subtype": "Stage 1",
+    "health": 140,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Chase Order",
+        "damage": "70+",
+        "cost": [
+          "Grass",
+          "Grass"
+        ],
+        "effect": "You may discard 1 of your Benched Basic Grass Pokémon. If you do, this attack does 70 more damage."
+      }
+    ],
+    "retreatCost": "2",
+    "weakness": "Fire",
+    "abilities": [],
+    "evolvesFrom": "Combee",
+    "rarity": "Full Art EX/Support"
+  },
+  {
+    "id": "b4-195",
+    "name": "Typhlosion ex",
+    "element": "Fire",
+    "type": "Pokemon",
+    "subtype": "Stage 2",
+    "health": 180,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Destructive Inferno",
+        "damage": "110",
+        "cost": [
+          "Fire",
+          "Fire",
+          "Colorless"
+        ],
+        "effect": "Flip a coin until you get tails. For each heads, discard a random Energy from your opponent's Active Pokémon."
+      }
+    ],
+    "retreatCost": "2",
+    "weakness": "Water",
+    "abilities": [],
+    "evolvesFrom": "Quilava",
+    "rarity": "Full Art EX/Support"
+  },
+  {
+    "id": "b4-196",
+    "name": "Mega Sharpedo ex",
+    "element": "Water",
+    "type": "Pokemon",
+    "subtype": "Stage 1",
+    "health": 190,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Turbo Shark",
+        "damage": "70",
+        "cost": [
+          "Water"
+        ],
+        "effect": "Take a Water Energy from your Energy Zone and attach it to 1 of your Benched Water Pokémon."
+      }
+    ],
+    "retreatCost": "0",
+    "weakness": "Lightning",
+    "abilities": [],
+    "evolvesFrom": "Carvanha",
+    "rarity": "Full Art EX/Support"
+  },
+  {
+    "id": "b4-197",
+    "name": "Wailord ex",
+    "element": "Water",
+    "type": "Pokemon",
+    "subtype": "Stage 1",
+    "health": 250,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Wondrous Waves",
+        "damage": "100",
+        "cost": [
+          "Water",
+          "Water",
+          "Water",
+          "Water"
+        ],
+        "effect": "This Pokémon recovers from all Special Conditions."
+      }
+    ],
+    "retreatCost": "4",
+    "weakness": "Lightning",
+    "abilities": [],
+    "evolvesFrom": "Wailmer",
+    "rarity": "Full Art EX/Support"
+  },
+  {
+    "id": "b4-198",
+    "name": "Mega Gallade ex",
+    "element": "Fighting",
+    "type": "Pokemon",
+    "subtype": "Stage 2",
+    "health": 220,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Resonating Blade",
+        "damage": "100+",
+        "cost": [
+          "Fighting",
+          "Colorless",
+          "Colorless"
+        ],
+        "effect": "If you played a Supporter card from your hand during this turn, this attack does 50 more damage."
+      }
+    ],
+    "retreatCost": "2",
+    "weakness": "Psychic",
+    "abilities": [],
+    "evolvesFrom": "Kirlia",
+    "rarity": "Full Art EX/Support"
+  },
+  {
+    "id": "b4-199",
+    "name": "Hoopa ex",
+    "element": "Darkness",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 150,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Shadow Bullet",
+        "damage": "30",
+        "cost": [
+          "Darkness"
+        ],
+        "effect": "This attack also does 20 damage to 1 of your opponent's Benched Pokémon."
+      },
+      {
+        "name": "Dynamite Punch",
+        "damage": "100",
+        "cost": [
+          "Darkness",
+          "Darkness",
+          "Colorless"
+        ],
+        "effect": "This Pokémon also does 20 damage to itself."
+      }
+    ],
+    "retreatCost": "2",
+    "weakness": "Grass",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Full Art EX/Support"
+  },
+  {
+    "id": "b4-200",
+    "name": "Mega Metagross ex",
+    "element": "Metal",
+    "type": "Pokemon",
+    "subtype": "Stage 2",
+    "health": 230,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Gatling Slug",
+        "damage": "100+",
+        "cost": [
+          "Colorless",
+          "Colorless",
+          "Colorless"
+        ],
+        "effect": "This attack does 10 more damage for each Metal Energy attached to this Pokémon."
+      }
+    ],
+    "retreatCost": "3",
+    "weakness": "Fire",
+    "abilities": [],
+    "evolvesFrom": "Metang",
+    "rarity": "Full Art EX/Support"
+  },
+  {
+    "id": "b4-201",
+    "name": "Swanna ex",
+    "element": "Colorless",
+    "type": "Pokemon",
+    "subtype": "Stage 1",
+    "health": 150,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Jet Wing",
+        "damage": "140",
+        "cost": [
+          "Colorless",
+          "Colorless",
+          "Colorless"
+        ],
+        "effect": "During your next turn, this Pokémon can't attack."
+      }
+    ],
+    "retreatCost": "2",
+    "weakness": "Lightning",
+    "abilities": [],
+    "evolvesFrom": "Ducklett",
+    "rarity": "Full Art EX/Support"
+  },
+  {
+    "id": "b4-202",
+    "name": "Rotom ex",
+    "element": "Lightning",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 120,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Junk Spark",
+        "damage": "30+",
+        "cost": [
+          "Lightning",
+          "Lightning"
+        ],
+        "effect": "This attack does 10 more damage for each Item card in your discard pile."
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Fighting",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Immersive"
+  },
+  {
+    "id": "b4-203",
+    "name": "Mega Rayquaza ex",
+    "element": "Dragon",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 180,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Mega Burst",
+        "damage": "50x",
+        "cost": [
+          "Fire",
+          "Lightning"
+        ],
+        "effect": "Discard all Fire and Lightning Energy from this Pokémon, and this attack does 50 damage for each Energy you discarded in this way."
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": null,
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Immersive"
+  },
+  {
+    "id": "b4-204",
+    "name": "Alolan Vulpix",
+    "element": "Water",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 60,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Gnaw",
+        "damage": "20",
+        "cost": [
+          "Water"
+        ]
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Metal",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "One shiny star"
+  },
+  {
+    "id": "b4-205",
+    "name": "Mudkip",
+    "element": "Water",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 60,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Tackle",
+        "damage": "20",
+        "cost": [
+          "Water"
+        ]
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Lightning",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "One shiny star"
+  },
+  {
+    "id": "b4-206",
+    "name": "Marshtomp",
+    "element": "Water",
+    "type": "Pokemon",
+    "subtype": "Stage 1",
+    "health": 90,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Surf",
+        "damage": "40",
+        "cost": [
+          "Water",
+          "Colorless"
+        ]
+      }
+    ],
+    "retreatCost": "2",
+    "weakness": "Lightning",
+    "abilities": [],
+    "evolvesFrom": "Mudkip",
+    "rarity": "One shiny star"
+  },
+  {
+    "id": "b4-207",
+    "name": "Swampert",
+    "element": "Water",
+    "type": "Pokemon",
+    "subtype": "Stage 2",
+    "health": 150,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Large Whirlpool",
+        "damage": "100",
+        "cost": [
+          "Water",
+          "Water",
+          "Water"
+        ],
+        "effect": "Discard a random Energy from among the Energy attached to all Pokémon (both yours and your opponent's)."
+      }
+    ],
+    "retreatCost": "3",
+    "weakness": "Lightning",
+    "abilities": [],
+    "evolvesFrom": "Marshtomp",
+    "rarity": "One shiny star"
+  },
+  {
+    "id": "b4-208",
+    "name": "Electabuzz",
+    "element": "Lightning",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 70,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Head Bolt",
+        "damage": "30",
+        "cost": [
+          "Lightning"
+        ]
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Fighting",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "One shiny star"
+  },
+  {
+    "id": "b4-209",
+    "name": "Plusle",
+    "element": "Lightning",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 70,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Electric Tail",
+        "damage": "10",
+        "cost": [
+          "Lightning"
+        ],
+        "effect": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Fighting",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "One shiny star"
+  },
+  {
+    "id": "b4-210",
+    "name": "Minun",
+    "element": "Lightning",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 70,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Buddy Spark",
+        "damage": "30",
+        "cost": [
+          "Lightning"
+        ],
+        "effect": "If Plusle is on your Bench, this attack also does 10 damage to each of your opponent's Benched Pokémon."
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Fighting",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "One shiny star"
+  },
+  {
+    "id": "b4-211",
+    "name": "Mr. Mime",
+    "element": "Psychic",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 70,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Synchro Dance",
+        "damage": "40+",
+        "cost": [
+          "Psychic",
+          "Colorless"
+        ],
+        "effect": "If this Pokémon and your opponent's Active Pokémon have the same amount of Energy attached, this attack does 40 more damage."
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Darkness",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "One shiny star"
+  },
+  {
+    "id": "b4-212",
+    "name": "Mewtwo",
+    "element": "Psychic",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 120,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Psychic",
+        "damage": "10+",
+        "cost": [
+          "Psychic",
+          "Psychic",
+          "Psychic"
+        ],
+        "effect": "This attack does 40 more damage for each Energy attached to your opponent's Active Pokémon."
+      }
+    ],
+    "retreatCost": "2",
+    "weakness": "Darkness",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "One shiny star"
+  },
+  {
+    "id": "b4-213",
+    "name": "Roggenrola",
+    "element": "Fighting",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 70,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Mud-Slap",
+        "damage": "30",
+        "cost": [
+          "Fighting",
+          "Colorless"
+        ]
+      }
+    ],
+    "retreatCost": "2",
+    "weakness": "Grass",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "One shiny star"
+  },
+  {
+    "id": "b4-214",
+    "name": "Boldore",
+    "element": "Fighting",
+    "type": "Pokemon",
+    "subtype": "Stage 1",
+    "health": 100,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Power Gem",
+        "damage": "70",
+        "cost": [
+          "Fighting",
+          "Fighting",
+          "Colorless"
+        ]
+      }
+    ],
+    "retreatCost": "3",
+    "weakness": "Grass",
+    "abilities": [],
+    "evolvesFrom": "Roggenrola",
+    "rarity": "One shiny star"
+  },
+  {
+    "id": "b4-215",
+    "name": "Falinks",
+    "element": "Fighting",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 70,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Invade",
+        "damage": "20",
+        "cost": [
+          "Fighting"
+        ]
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Psychic",
+    "abilities": [
+      {
+        "name": "Coordinated Unit",
+        "effect": "If you have another Falinks in play, this Pokémon's attacks do +20 damage to your opponent's Active Pokémon, and this Pokémon takes −20 damage from attacks from your opponent's Pokémon."
+      }
+    ],
+    "evolvesFrom": null,
+    "rarity": "One shiny star"
+  },
+  {
+    "id": "b4-216",
+    "name": "Koffing",
+    "element": "Darkness",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 70,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Gas Bomb",
+        "damage": "30",
+        "cost": [
+          "Darkness"
+        ],
+        "effect": "This Pokémon also does 10 damage to itself."
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Fighting",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "One shiny star"
+  },
+  {
+    "id": "b4-217",
+    "name": "Weezing",
+    "element": "Darkness",
+    "type": "Pokemon",
+    "subtype": "Stage 1",
+    "health": 110,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Sludge Bomb",
+        "damage": "70",
+        "cost": [
+          "Darkness",
+          "Darkness"
+        ]
+      }
+    ],
+    "retreatCost": "2",
+    "weakness": "Fighting",
+    "abilities": [],
+    "evolvesFrom": "Koffing",
+    "rarity": "One shiny star"
+  },
+  {
+    "id": "b4-218",
+    "name": "Galarian Meowth",
+    "element": "Metal",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 60,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Slash",
+        "damage": "20",
+        "cost": [
+          "Metal"
+        ]
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Fire",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "One shiny star"
+  },
+  {
+    "id": "b4-219",
+    "name": "Galarian Perrserker",
+    "element": "Metal",
+    "type": "Pokemon",
+    "subtype": "Stage 1",
+    "health": 100,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Metal Claw",
+        "damage": "70",
+        "cost": [
+          "Metal",
+          "Metal"
+        ]
+      }
+    ],
+    "retreatCost": "2",
+    "weakness": "Fire",
+    "abilities": [
+      {
+        "name": "Dig Up",
+        "effect": "Once during your turn, when you play this Pokémon from your hand to evolve 1 of your Pokémon, you may put 2 random Pokémon Tool cards from your discard pile into your hand."
+      }
+    ],
+    "evolvesFrom": "Galarian Meowth",
+    "rarity": "One shiny star"
+  },
+  {
+    "id": "b4-220",
+    "name": "Rattata",
+    "element": "Colorless",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 50,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Surprise Attack",
+        "damage": "40",
+        "cost": [
+          "Colorless"
+        ],
+        "effect": "Flip a coin. If tails, this attack does nothing."
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Fighting",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "One shiny star"
+  },
+  {
+    "id": "b4-221",
+    "name": "Raticate",
+    "element": "Colorless",
+    "type": "Pokemon",
+    "subtype": "Stage 1",
+    "health": 80,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Speed Attack",
+        "damage": "40",
+        "cost": [
+          "Colorless",
+          "Colorless"
+        ]
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Fighting",
+    "abilities": [
+      {
+        "name": "Treasure Collecting",
+        "effect": "Once during your turn, when you play this Pokémon from your hand to evolve 1 of your Pokémon, you may look at the top 4 cards of your deck and put all Item cards you find there into your hand. Shuffle the other cards back into your deck."
+      }
+    ],
+    "evolvesFrom": "Rattata",
+    "rarity": "One shiny star"
+  },
+  {
+    "id": "b4-222",
+    "name": "Smeargle",
+    "element": "Colorless",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 60,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Tail Whap",
+        "damage": "30",
+        "cost": [
+          "Colorless",
+          "Colorless"
+        ]
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Fighting",
+    "abilities": [
+      {
+        "name": "Portrait",
+        "effect": "Once during your turn, if this Pokémon is in the Active Spot, you may look at a random Supporter card from your opponent's hand. Use the effect of that card as the effect of this Ability."
+      }
+    ],
+    "evolvesFrom": null,
+    "rarity": "One shiny star"
+  },
+  {
+    "id": "b4-223",
+    "name": "Buneary",
+    "element": "Colorless",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 60,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Double Kick",
+        "damage": "20x",
+        "cost": [
+          "Colorless"
+        ],
+        "effect": "Flip 2 coins. This attack does 20 damage for each heads."
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Fighting",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "One shiny star"
+  },
+  {
+    "id": "b4-224",
+    "name": "Blacephalon ex",
+    "element": "Fire",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 140,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Singe",
+        "damage": "",
+        "cost": [
+          "Fire"
+        ],
+        "effect": "Your opponent's Active Pokémon is now Burned."
+      },
+      {
+        "name": "Pop-Punk",
+        "damage": "140",
+        "cost": [
+          "Fire",
+          "Fire",
+          "Fire"
+        ],
+        "effect": "Discard 3 Fire Energy from this Pokémon."
+      }
+    ],
+    "retreatCost": "2",
+    "weakness": "Water",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Two shiny stars"
+  },
+  {
+    "id": "b4-225",
+    "name": "Alolan Ninetales ex",
+    "element": "Water",
+    "type": "Pokemon",
+    "subtype": "Stage 1",
+    "health": 150,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Binding Snow",
+        "damage": "80",
+        "cost": [
+          "Water",
+          "Water"
+        ],
+        "effect": "During your opponent's next turn, they can't take any Energy from their Energy Zone to attach to their Active Pokémon."
+      }
+    ],
+    "retreatCost": "2",
+    "weakness": "Metal",
+    "abilities": [],
+    "evolvesFrom": "Alolan Vulpix",
+    "rarity": "Two shiny stars"
+  },
+  {
+    "id": "b4-226",
+    "name": "Mega Swampert ex",
+    "element": "Water",
+    "type": "Pokemon",
+    "subtype": "Stage 2",
+    "health": 230,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Strong-Armed Destroyer",
+        "damage": "150",
+        "cost": [
+          "Water",
+          "Water",
+          "Water"
+        ],
+        "effect": "Discard 2 random Energy from among the Energy attached to all Pokémon (both yours and your opponent's)."
+      }
+    ],
+    "retreatCost": "3",
+    "weakness": "Lightning",
+    "abilities": [],
+    "evolvesFrom": "Marshtomp",
+    "rarity": "Two shiny stars"
+  },
+  {
+    "id": "b4-227",
+    "name": "Mega Gardevoir ex",
+    "element": "Psychic",
+    "type": "Pokemon",
+    "subtype": "Stage 2",
+    "health": 210,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Fantasia Force",
+        "damage": "110",
+        "cost": [
+          "Psychic",
+          "Psychic"
+        ],
+        "effect": "Take 3 Psychic Energy from your Energy Zone and attach it to your Psychic Pokémon in any way you like."
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Darkness",
+    "abilities": [],
+    "evolvesFrom": "Kirlia",
+    "rarity": "Two shiny stars"
+  },
+  {
+    "id": "b4-228",
+    "name": "Mega Lopunny ex",
+    "element": "Fighting",
+    "type": "Pokemon",
+    "subtype": "Stage 1",
+    "health": 190,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Rapid Smashers",
+        "damage": "90x",
+        "cost": [
+          "Fighting",
+          "Fighting"
+        ],
+        "effect": "Flip 2 coins. This attack does 90 damage for each heads. Your opponent's Active Pokémon is now Confused."
+      }
+    ],
+    "retreatCost": "1",
+    "weakness": "Psychic",
+    "abilities": [],
+    "evolvesFrom": "Buneary",
+    "rarity": "Two shiny stars"
+  },
+  {
+    "id": "b4-229",
+    "name": "Gigalith ex",
+    "element": "Fighting",
+    "type": "Pokemon",
+    "subtype": "Stage 2",
+    "health": 190,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Megaton Cannon",
+        "damage": "",
+        "cost": [
+          "Fighting",
+          "Fighting",
+          "Fighting",
+          "Fighting"
+        ],
+        "effect": "This attack does 140 damage to 1 of your opponent's Pokémon. During your next turn, this Pokémon can't attack."
+      }
+    ],
+    "retreatCost": "4",
+    "weakness": "Grass",
+    "abilities": [],
+    "evolvesFrom": "Boldore",
+    "rarity": "Two shiny stars"
+  },
+  {
+    "id": "b4-230",
+    "name": "Zoroark ex",
+    "element": "Darkness",
+    "type": "Pokemon",
+    "subtype": "Stage 1",
+    "health": 150,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Brutal Bash",
+        "damage": "30x",
+        "cost": [
+          "Darkness"
+        ],
+        "effect": "This attack does 30 damage for each of your Benched Darkness Pokémon."
+      }
+    ],
+    "retreatCost": "2",
+    "weakness": "Grass",
+    "abilities": [],
+    "evolvesFrom": "Zorua",
+    "rarity": "Two shiny stars"
+  },
+  {
+    "id": "b4-231",
+    "name": "Mega Kangaskhan ex",
+    "element": "Colorless",
+    "type": "Pokemon",
+    "subtype": "Basic",
+    "health": 180,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Double-Punching Family",
+        "damage": "80",
+        "cost": [
+          "Colorless",
+          "Colorless",
+          "Colorless"
+        ],
+        "effect": "This attack is used twice in a row. The second attack does 40 damage. (If the first attack Knocks Out your opponent's Active Pokémon, the second attack is used after your opponent chooses a new Active Pokémon.)"
+      }
+    ],
+    "retreatCost": "3",
+    "weakness": "Fighting",
+    "abilities": [],
+    "evolvesFrom": null,
+    "rarity": "Two shiny stars"
+  },
+  {
+    "id": "b4-232",
+    "name": "Raichu",
+    "element": "Lightning",
+    "type": "Pokemon",
+    "subtype": "Stage 1",
+    "health": 100,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Electro Ball",
+        "damage": "50",
+        "cost": [
+          "Lightning",
+          "Colorless"
+        ]
+      }
+    ],
+    "retreatCost": "2",
+    "weakness": "Fighting",
+    "abilities": [
+      {
+        "name": "Evoshock",
+        "effect": "Once during your turn, when you play this Pokémon from your hand to evolve 1 of your Pokémon, you may flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
+      }
+    ],
+    "evolvesFrom": "Pikachu",
+    "rarity": "Gold Crown"
+  },
+  {
+    "id": "b4-233",
+    "name": "Dragonair",
+    "element": "Dragon",
+    "type": "Pokemon",
+    "subtype": "Stage 1",
+    "health": 80,
+    "set": "Ruler of the Skies (B4)",
+    "pack": null,
+    "attacks": [
+      {
+        "name": "Draconic Whip",
+        "damage": "40",
+        "cost": [
+          "Colorless",
+          "Colorless"
+        ]
+      }
+    ],
+    "retreatCost": "2",
+    "weakness": null,
+    "abilities": [
+      {
+        "name": "Dragon’s Blessing",
+        "effect": "Once during your turn, if this Pokémon is on your Bench, you may attach an Energy from your discard pile to your Active Dragon Pokémon."
+      }
+    ],
+    "evolvesFrom": "Dratini",
+    "rarity": "Gold Crown"
+  }
+]

--- a/cards/en/index.js
+++ b/cards/en/index.js
@@ -18,6 +18,7 @@ const paldeanWonders = require('./b2a-paldean-wonders.json');
 const megaShine = require('./b2b-mega-shine.json');
 const pulsingAura = require('./b3-pulsing-aura.json');
 const paradoxDrive = require('./b3a-paradox-drive.json');
+const rulerOfTheSkies = require('./b4-ruler-of-the-skies.json');
 
 module.exports = {
   promoA,
@@ -40,4 +41,5 @@ module.exports = {
   megaShine,
   pulsingAura,
   paradoxDrive,
+  rulerOfTheSkies,
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pokemon-tcg-pocket-card-database",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "A card database for the pokemon TCG pocket mobile game.",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
## Summary

- add all 233 English cards from Ruler of the Skies (B4)
- export the new set as rulerOfTheSkies
- bump the package version to 0.0.14

## Why

The database currently stops at Paradox Drive (B3a), so the latest Rayquaza-focused expansion is missing.

## Validation

- reconciled all 233 cards field by field across three current card datasets, including Limitless-derived card details
- checked IDs, names, card types, rarities, attacks, energy costs, effects, abilities, weaknesses, retreat costs, and evolution links
- loaded the package and confirmed all 233 cards are exported
- ran npm pack --dry-run and confirmed the B4 JSON is included
- ran git diff --check